### PR TITLE
#10 event repository list undelivered events

### DIFF
--- a/WalletWasabi.Tests/Helpers/TestException.cs
+++ b/WalletWasabi.Tests/Helpers/TestException.cs
@@ -1,0 +1,23 @@
+using System.Runtime.Serialization;
+
+namespace WalletWasabi.Tests.Helpers
+{
+	public class TestException : Exception
+	{
+		public TestException()
+		{
+		}
+
+		public TestException(string? message) : base(message)
+		{
+		}
+
+		public TestException(string? message, Exception? innerException) : base(message, innerException)
+		{
+		}
+
+		protected TestException(SerializationInfo info, StreamingContext context) : base(info, context)
+		{
+		}
+	}
+}

--- a/WalletWasabi.Tests/UnitTests/EventSourcing/InMemoryEventRepositoryTests.cs
+++ b/WalletWasabi.Tests/UnitTests/EventSourcing/InMemoryEventRepositoryTests.cs
@@ -260,7 +260,7 @@ namespace WalletWasabi.Tests.UnitTests.EventSourcing
 			}
 			async Task Append2Async()
 			{
-				Assert.True(TestEventRepository.AppendedSemaphore.Wait(_semaphoreWaitTimeout));
+				Assert.True(TestEventRepository.Append_AppendedSemaphore.Wait(_semaphoreWaitTimeout));
 				await EventRepository.AppendEventsAsync(nameof(TestRoundAggregate), "MY_ID_1", events2!);
 			}
 			async Task AppendInParallelAsync()
@@ -271,9 +271,9 @@ namespace WalletWasabi.Tests.UnitTests.EventSourcing
 			}
 			void WaitForConflict()
 			{
-				Assert.True(TestEventRepository.ConflictedSemaphore.Wait(_semaphoreWaitTimeout));
+				Assert.True(TestEventRepository.Append_ConflictedSemaphore.Wait(_semaphoreWaitTimeout));
 			}
-			TestEventRepository.AppendedCallback = WaitForConflict;
+			TestEventRepository.Append_AppendedCallback = WaitForConflict;
 
 			// Assert
 			await Assert.ThrowsAsync<OptimisticConcurrencyException>(AppendInParallelAsync);
@@ -300,7 +300,7 @@ namespace WalletWasabi.Tests.UnitTests.EventSourcing
 			}
 			async Task Append2Async()
 			{
-				Assert.True(TestEventRepository.AppendedSemaphore.Wait(_semaphoreWaitTimeout));
+				Assert.True(TestEventRepository.Append_AppendedSemaphore.Wait(_semaphoreWaitTimeout));
 				await EventRepository.AppendEventsAsync(nameof(TestRoundAggregate), "MY_ID_1", events2!);
 			}
 			async Task AppendInParallelAsync()
@@ -311,9 +311,9 @@ namespace WalletWasabi.Tests.UnitTests.EventSourcing
 			}
 			void WaitForNoConflict()
 			{
-				Assert.False(TestEventRepository.ConflictedSemaphore.Wait(_semaphoreWaitTimeout));
+				Assert.False(TestEventRepository.Append_ConflictedSemaphore.Wait(_semaphoreWaitTimeout));
 			}
-			TestEventRepository.AppendedCallback = WaitForNoConflict;
+			TestEventRepository.Append_AppendedCallback = WaitForNoConflict;
 
 			// no conflict
 			await AppendInParallelAsync();
@@ -328,8 +328,8 @@ namespace WalletWasabi.Tests.UnitTests.EventSourcing
 		}
 
 		[Theory]
-		[InlineData(nameof(TestInMemoryEventRepository.ValidatedCallback))]
-		[InlineData(nameof(TestInMemoryEventRepository.AppendedCallback))]
+		[InlineData(nameof(TestInMemoryEventRepository.Append_ValidatedCallback))]
+		[InlineData(nameof(TestInMemoryEventRepository.Append_AppendedCallback))]
 		public async Task ListEventsAsync_ConflictWithAppending_Async(string listOnCallback)
 		{
 			// Arrange
@@ -349,12 +349,12 @@ namespace WalletWasabi.Tests.UnitTests.EventSourcing
 			}
 			switch (listOnCallback)
 			{
-				case nameof(TestInMemoryEventRepository.ValidatedCallback):
-					TestEventRepository.ValidatedCallback = ListCallback;
+				case nameof(TestInMemoryEventRepository.Append_ValidatedCallback):
+					TestEventRepository.Append_ValidatedCallback = ListCallback;
 					break;
 
-				case nameof(TestInMemoryEventRepository.AppendedCallback):
-					TestEventRepository.AppendedCallback = ListCallback;
+				case nameof(TestInMemoryEventRepository.Append_AppendedCallback):
+					TestEventRepository.Append_AppendedCallback = ListCallback;
 					break;
 
 				default:
@@ -366,7 +366,7 @@ namespace WalletWasabi.Tests.UnitTests.EventSourcing
 			var expected = events1.AsEnumerable();
 			switch (listOnCallback)
 			{
-				case nameof(TestInMemoryEventRepository.AppendedCallback):
+				case nameof(TestInMemoryEventRepository.Append_AppendedCallback):
 					expected = expected.Concat(events2);
 					break;
 			}

--- a/WalletWasabi.Tests/UnitTests/EventSourcing/InMemoryEventRepositoryTests.cs
+++ b/WalletWasabi.Tests/UnitTests/EventSourcing/InMemoryEventRepositoryTests.cs
@@ -2,11 +2,13 @@ using Shouldly;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using WalletWasabi.EventSourcing.Exceptions;
 using WalletWasabi.EventSourcing.Interfaces;
 using WalletWasabi.EventSourcing.Records;
 using WalletWasabi.Helpers;
+using WalletWasabi.Tests.Helpers;
 using WalletWasabi.Tests.UnitTests.EventSourcing.TestDomain;
 using Xunit;
 using Xunit.Abstractions;
@@ -15,6 +17,8 @@ namespace WalletWasabi.Tests.UnitTests.EventSourcing
 {
 	public class InMemoryEventRepositoryTests : IDisposable
 	{
+		private const string ID_1 = "ID_1";
+		private const string ID_2 = "ID_2";
 		private readonly TimeSpan _semaphoreWaitTimeout = TimeSpan.FromSeconds(5);
 
 		public InMemoryEventRepositoryTests(ITestOutputHelper output)
@@ -33,13 +37,13 @@ namespace WalletWasabi.Tests.UnitTests.EventSourcing
 			var events = Array.Empty<WrappedEvent>();
 
 			// Act
-			await EventRepository.AppendEventsAsync(nameof(TestRoundAggregate), "MY_ID_1", events);
+			await EventRepository.AppendEventsAsync(nameof(TestRoundAggregate), ID_1, events);
 
 			// Assert
-			Assert.True((await EventRepository.ListEventsAsync(nameof(TestRoundAggregate), "MY_ID_1"))
+			Assert.True((await EventRepository.ListEventsAsync(nameof(TestRoundAggregate), ID_1))
 				.SequenceEqual(events));
 			Assert.DoesNotContain(await EventRepository.ListUndeliveredEventsAsync(),
-				a => a.AggregateType == nameof(TestRoundAggregate) && a.AggregateId == "MY_ID_1");
+				a => a.AggregateType == nameof(TestRoundAggregate) && a.AggregateId == ID_1);
 			Assert.True((await EventRepository.ListAggregateIdsAsync(nameof(TestRoundAggregate)))
 				.SequenceEqual(Array.Empty<string>()));
 		}
@@ -54,17 +58,17 @@ namespace WalletWasabi.Tests.UnitTests.EventSourcing
 			};
 
 			// Act
-			await EventRepository.AppendEventsAsync(nameof(TestRoundAggregate), "MY_ID_1", events);
+			await EventRepository.AppendEventsAsync(nameof(TestRoundAggregate), ID_1, events);
 
 			// Assert
-			Assert.True((await EventRepository.ListEventsAsync(nameof(TestRoundAggregate), "MY_ID_1"))
+			Assert.True((await EventRepository.ListEventsAsync(nameof(TestRoundAggregate), ID_1))
 				.SequenceEqual(events));
 			Assert.True((await EventRepository.ListUndeliveredEventsAsync())
-				.First(a => a.AggregateType == nameof(TestRoundAggregate) && a.AggregateId == "MY_ID_1")
+				.First(a => a.AggregateType == nameof(TestRoundAggregate) && a.AggregateId == ID_1)
 				.WrappedEvents
 				.SequenceEqual(events));
 			Assert.True((await EventRepository.ListAggregateIdsAsync(nameof(TestRoundAggregate)))
-				.SequenceEqual(new[] { "MY_ID_1" }));
+				.SequenceEqual(new[] { ID_1 }));
 		}
 
 		[Fact]
@@ -78,17 +82,17 @@ namespace WalletWasabi.Tests.UnitTests.EventSourcing
 			};
 
 			// Act
-			await EventRepository.AppendEventsAsync(nameof(TestRoundAggregate), "MY_ID_1", events);
+			await EventRepository.AppendEventsAsync(nameof(TestRoundAggregate), ID_1, events);
 
 			// Assert
-			Assert.True((await EventRepository.ListEventsAsync(nameof(TestRoundAggregate), "MY_ID_1"))
+			Assert.True((await EventRepository.ListEventsAsync(nameof(TestRoundAggregate), ID_1))
 				.SequenceEqual(events));
 			Assert.True((await EventRepository.ListUndeliveredEventsAsync())
-				.First(a => a.AggregateType == nameof(TestRoundAggregate) && a.AggregateId == "MY_ID_1")
+				.First(a => a.AggregateType == nameof(TestRoundAggregate) && a.AggregateId == ID_1)
 				.WrappedEvents
 				.SequenceEqual(events));
 			Assert.True((await EventRepository.ListAggregateIdsAsync(nameof(TestRoundAggregate)))
-				.SequenceEqual(new[] { "MY_ID_1" }));
+				.SequenceEqual(new[] { ID_1 }));
 		}
 
 		[Fact]
@@ -103,7 +107,7 @@ namespace WalletWasabi.Tests.UnitTests.EventSourcing
 			// Act
 			async Task ActionAsync()
 			{
-				await EventRepository.AppendEventsAsync(nameof(TestRoundAggregate), "MY_ID_1", events).ConfigureAwait(false);
+				await EventRepository.AppendEventsAsync(nameof(TestRoundAggregate), ID_1, events).ConfigureAwait(false);
 			}
 
 			// Assert
@@ -123,7 +127,7 @@ namespace WalletWasabi.Tests.UnitTests.EventSourcing
 			// Act
 			async Task ActionAsync()
 			{
-				await EventRepository.AppendEventsAsync(nameof(TestRoundAggregate), "MY_ID_1", events);
+				await EventRepository.AppendEventsAsync(nameof(TestRoundAggregate), ID_1, events);
 			}
 
 			// Assert
@@ -141,12 +145,12 @@ namespace WalletWasabi.Tests.UnitTests.EventSourcing
 			{
 				new TestWrappedEvent(1)
 			};
-			await EventRepository.AppendEventsAsync(nameof(TestRoundAggregate), "MY_ID_1", events);
+			await EventRepository.AppendEventsAsync(nameof(TestRoundAggregate), ID_1, events);
 
 			// Act
 			async Task ActionAsync()
 			{
-				await EventRepository.AppendEventsAsync(nameof(TestRoundAggregate), "MY_ID_1", events);
+				await EventRepository.AppendEventsAsync(nameof(TestRoundAggregate), ID_1, events);
 			}
 
 			// Assert
@@ -231,19 +235,19 @@ namespace WalletWasabi.Tests.UnitTests.EventSourcing
 			// Act
 			async Task ActionAsync()
 			{
-				await EventRepository.AppendEventsAsync(nameof(TestRoundAggregate), "MY_ID_1", events1);
-				await EventRepository.AppendEventsAsync(nameof(TestRoundAggregate), "MY_ID_1", events2);
+				await EventRepository.AppendEventsAsync(nameof(TestRoundAggregate), ID_1, events1);
+				await EventRepository.AppendEventsAsync(nameof(TestRoundAggregate), ID_1, events2);
 			}
 
 			// Assert
 			await Assert.ThrowsAsync<OptimisticConcurrencyException>(ActionAsync);
-			Assert.True((await EventRepository.ListEventsAsync(nameof(TestRoundAggregate), "MY_ID_1"))
+			Assert.True((await EventRepository.ListEventsAsync(nameof(TestRoundAggregate), ID_1))
 				.Cast<TestWrappedEvent>().SequenceEqual(events1));
 			Assert.True((await EventRepository.ListUndeliveredEventsAsync())
-				.First(a => a.AggregateType == nameof(TestRoundAggregate) && a.AggregateId == "MY_ID_1")
+				.First(a => a.AggregateType == nameof(TestRoundAggregate) && a.AggregateId == ID_1)
 				.WrappedEvents.Cast<TestWrappedEvent>().SequenceEqual(events1));
 			Assert.True((await EventRepository.ListAggregateIdsAsync(nameof(TestRoundAggregate)))
-				.SequenceEqual(new[] { "MY_ID_1" }));
+				.SequenceEqual(new[] { ID_1 }));
 		}
 
 #if DEBUG
@@ -258,12 +262,12 @@ namespace WalletWasabi.Tests.UnitTests.EventSourcing
 			// Act
 			async Task Append1Async()
 			{
-				await EventRepository.AppendEventsAsync(nameof(TestRoundAggregate), "MY_ID_1", events1);
+				await EventRepository.AppendEventsAsync(nameof(TestRoundAggregate), ID_1, events1);
 			}
 			async Task Append2Async()
 			{
 				Assert.True(await TestEventRepository.Append_AppendedSemaphore.WaitAsync(_semaphoreWaitTimeout));
-				await EventRepository.AppendEventsAsync(nameof(TestRoundAggregate), "MY_ID_1", events2!);
+				await EventRepository.AppendEventsAsync(nameof(TestRoundAggregate), ID_1, events2!);
 			}
 			async Task AppendInParallelAsync()
 			{
@@ -279,13 +283,13 @@ namespace WalletWasabi.Tests.UnitTests.EventSourcing
 
 			// Assert
 			await Assert.ThrowsAsync<OptimisticConcurrencyException>(AppendInParallelAsync);
-			Assert.True((await EventRepository.ListEventsAsync(nameof(TestRoundAggregate), "MY_ID_1"))
+			Assert.True((await EventRepository.ListEventsAsync(nameof(TestRoundAggregate), ID_1))
 						.Cast<TestWrappedEvent>().SequenceEqual(events1));
 			Assert.True((await EventRepository.ListUndeliveredEventsAsync())
-				.First(a => a.AggregateType == nameof(TestRoundAggregate) && a.AggregateId == "MY_ID_1")
+				.First(a => a.AggregateType == nameof(TestRoundAggregate) && a.AggregateId == ID_1)
 				.WrappedEvents.Cast<TestWrappedEvent>().SequenceEqual(events1));
 			Assert.True((await EventRepository.ListAggregateIdsAsync(nameof(TestRoundAggregate)))
-				.SequenceEqual(new[] { "MY_ID_1" }));
+				.SequenceEqual(new[] { ID_1 }));
 		}
 
 		[Fact]
@@ -298,12 +302,12 @@ namespace WalletWasabi.Tests.UnitTests.EventSourcing
 			// Act
 			async Task Append1Async()
 			{
-				await EventRepository.AppendEventsAsync(nameof(TestRoundAggregate), "MY_ID_1", events1);
+				await EventRepository.AppendEventsAsync(nameof(TestRoundAggregate), ID_1, events1);
 			}
 			async Task Append2Async()
 			{
 				Assert.True(await TestEventRepository.Append_AppendedSemaphore.WaitAsync(_semaphoreWaitTimeout));
-				await EventRepository.AppendEventsAsync(nameof(TestRoundAggregate), "MY_ID_1", events2!);
+				await EventRepository.AppendEventsAsync(nameof(TestRoundAggregate), ID_1, events2!);
 			}
 			async Task AppendInParallelAsync()
 			{
@@ -320,13 +324,13 @@ namespace WalletWasabi.Tests.UnitTests.EventSourcing
 			// no conflict
 			await AppendInParallelAsync();
 
-			Assert.True((await EventRepository.ListEventsAsync(nameof(TestRoundAggregate), "MY_ID_1"))
+			Assert.True((await EventRepository.ListEventsAsync(nameof(TestRoundAggregate), ID_1))
 						.Cast<TestWrappedEvent>().SequenceEqual(events1.Concat(events2)));
 			Assert.True((await EventRepository.ListUndeliveredEventsAsync())
-				.First(a => a.AggregateType == nameof(TestRoundAggregate) && a.AggregateId == "MY_ID_1")
+				.First(a => a.AggregateType == nameof(TestRoundAggregate) && a.AggregateId == ID_1)
 				.WrappedEvents.Cast<TestWrappedEvent>().SequenceEqual(events1.Concat(events2)));
 			Assert.True((await EventRepository.ListAggregateIdsAsync(nameof(TestRoundAggregate)))
-				.SequenceEqual(new[] { "MY_ID_1" }));
+				.SequenceEqual(new[] { ID_1 }));
 		}
 
 		[Theory]
@@ -337,16 +341,16 @@ namespace WalletWasabi.Tests.UnitTests.EventSourcing
 			// Arrange
 			var events1 = new[] { new TestWrappedEvent(1, "a"), new TestWrappedEvent(2, "a") };
 			var events2 = new[] { new TestWrappedEvent(3, "b"), new TestWrappedEvent(4, "b") };
-			await EventRepository.AppendEventsAsync(nameof(TestRoundAggregate), "MY_ID_1", events1);
+			await EventRepository.AppendEventsAsync(nameof(TestRoundAggregate), ID_1, events1);
 
 			// Act
 			IReadOnlyList<WrappedEvent> result = ImmutableList<WrappedEvent>.Empty;
 			IReadOnlyList<WrappedEvent> result2 = ImmutableList<WrappedEvent>.Empty;
 			async Task ListCallback()
 			{
-				result = await EventRepository.ListEventsAsync(nameof(TestRoundAggregate), "MY_ID_1");
+				result = await EventRepository.ListEventsAsync(nameof(TestRoundAggregate), ID_1);
 				result2 = (await EventRepository.ListUndeliveredEventsAsync())
-					.First(a => a.AggregateType == nameof(TestRoundAggregate) && a.AggregateId == "MY_ID_1")
+					.First(a => a.AggregateType == nameof(TestRoundAggregate) && a.AggregateId == ID_1)
 					.WrappedEvents;
 			}
 			switch (listOnCallback)
@@ -362,7 +366,7 @@ namespace WalletWasabi.Tests.UnitTests.EventSourcing
 				default:
 					throw new ApplicationException($"unexpected value listOnCallback: '{listOnCallback}'");
 			}
-			await EventRepository.AppendEventsAsync(nameof(TestRoundAggregate), "MY_ID_1", events2);
+			await EventRepository.AppendEventsAsync(nameof(TestRoundAggregate), ID_1, events2);
 
 			// Assert
 			var expected = events1.AsEnumerable();
@@ -402,11 +406,11 @@ namespace WalletWasabi.Tests.UnitTests.EventSourcing
 				new TestWrappedEvent(1, "a"), new TestWrappedEvent(2, "a"),
 				new TestWrappedEvent(3, "b"), new TestWrappedEvent(4, "b")
 			};
-			await EventRepository.AppendEventsAsync(nameof(TestRoundAggregate), "MY_ID_1", events);
+			await EventRepository.AppendEventsAsync(nameof(TestRoundAggregate), ID_1, events);
 
 			// Act
 			var result = await EventRepository.ListEventsAsync(
-				nameof(TestRoundAggregate), "MY_ID_1", afterSequenceId, limit);
+				nameof(TestRoundAggregate), ID_1, afterSequenceId, limit);
 
 			// Assert
 			Assert.True(result.Count <= limit);
@@ -422,14 +426,14 @@ namespace WalletWasabi.Tests.UnitTests.EventSourcing
 				new TestWrappedEvent(1, "a"), new TestWrappedEvent(2, "a"),
 				new TestWrappedEvent(3, "b"), new TestWrappedEvent(4, "b")
 			};
-			await EventRepository.AppendEventsAsync(nameof(TestRoundAggregate), "MY_ID_1", events);
-			await EventRepository.AppendEventsAsync(nameof(TestRoundAggregate), "MY_ID_2", events);
+			await EventRepository.AppendEventsAsync(nameof(TestRoundAggregate), ID_1, events);
+			await EventRepository.AppendEventsAsync(nameof(TestRoundAggregate), ID_2, events);
 
 			// Act
 			var result = await EventRepository.ListAggregateIdsAsync(nameof(TestRoundAggregate));
 
 			// Assert
-			Assert.True(result.SequenceEqual(new[] { "MY_ID_1", "MY_ID_2" }));
+			Assert.True(result.SequenceEqual(new[] { ID_1, ID_2 }));
 		}
 
 		[Theory]
@@ -437,11 +441,11 @@ namespace WalletWasabi.Tests.UnitTests.EventSourcing
 		[InlineData("0", 1)]
 		[InlineData("0", 2)]
 		[InlineData("0", 3)]
-		[InlineData("MY_ID_1", 0)]
-		[InlineData("MY_ID_1", 1)]
-		[InlineData("MY_ID_1", 2)]
-		[InlineData("MY_ID_2", 0)]
-		[InlineData("MY_ID_2", 1)]
+		[InlineData(ID_1, 0)]
+		[InlineData(ID_1, 1)]
+		[InlineData(ID_1, 2)]
+		[InlineData(ID_2, 0)]
+		[InlineData(ID_2, 1)]
 		[InlineData("3", 0)]
 		[InlineData("3", 1)]
 		public async Task ListAggregateIdsAsync_OptionalArguments_Async(string afterAggregateId, int limit)
@@ -452,8 +456,8 @@ namespace WalletWasabi.Tests.UnitTests.EventSourcing
 				new TestWrappedEvent(1, "a"), new TestWrappedEvent(2, "a"),
 				new TestWrappedEvent(3, "b"), new TestWrappedEvent(4, "b")
 			};
-			await EventRepository.AppendEventsAsync(nameof(TestRoundAggregate), "MY_ID_1", events);
-			await EventRepository.AppendEventsAsync(nameof(TestRoundAggregate), "MY_ID_2", events);
+			await EventRepository.AppendEventsAsync(nameof(TestRoundAggregate), ID_1, events);
+			await EventRepository.AppendEventsAsync(nameof(TestRoundAggregate), ID_2, events);
 
 			// Act
 			var result = await EventRepository.ListAggregateIdsAsync(
@@ -488,12 +492,12 @@ namespace WalletWasabi.Tests.UnitTests.EventSourcing
 				new TestWrappedEvent(2),
 				new TestWrappedEvent(3),
 			}.Take(eventCount).ToArray();
-			await EventRepository.AppendEventsAsync(nameof(TestRoundAggregate), "MY_ID_1", events);
+			await EventRepository.AppendEventsAsync(nameof(TestRoundAggregate), ID_1, events);
 
 			// Act
 			async Task ActionAsync()
 			{
-				await EventRepository.MarkEventsAsDeliveredCumulativeAsync(nameof(TestRoundAggregate), "MY_ID_1", deliveredSequenceId);
+				await EventRepository.MarkEventsAsDeliveredCumulativeAsync(nameof(TestRoundAggregate), ID_1, deliveredSequenceId);
 			}
 
 			// Assert
@@ -515,7 +519,7 @@ namespace WalletWasabi.Tests.UnitTests.EventSourcing
 				{
 					undeliveredEvents.Count.ShouldBe(1);
 					undeliveredEvents[0].AggregateType.ShouldBe(nameof(TestRoundAggregate));
-					undeliveredEvents[0].AggregateId.ShouldBe("MY_ID_1");
+					undeliveredEvents[0].AggregateId.ShouldBe(ID_1);
 					undeliveredEvents[0].WrappedEvents.Cast<TestWrappedEvent>().ShouldBe(events.Skip(deliveredSequenceId));
 				}
 				else if (deliveredSequenceId == eventCount)
@@ -679,17 +683,236 @@ namespace WalletWasabi.Tests.UnitTests.EventSourcing
 			await AssertAsync(bEvents, "MY_ID_B", bDeliveredSequenceIds, bEventsCount, ActionB_Async);
 		}
 
+		private Func<Task> PrepareAppendWithConflict(int conflictedEvents, int appendedEvents, Func<Task>? beforeAppend = null, string id = ID_1)
+		{
+			Guard.InRangeAndNotNull(nameof(conflictedEvents), conflictedEvents, 0, 4);
+			Guard.InRangeAndNotNull(nameof(appendedEvents), appendedEvents, 0, 3);
+
+			var appendAsync = async () =>
+			{
+				await EventRepository.AppendEventsAsync(nameof(TestRoundAggregate), id, new TestWrappedEvent[]
+				{
+					new(1, "a1"),
+					new(2, "a2"),
+					new(3, "a3"),
+					new(4, "a4"),
+				}.Take(conflictedEvents));
+			};
+
+			// After first AppendEventsAsync() call marks events as undelivered but before
+			// they are actually appended to the repository
+			TestEventRepository.Append_MarkedUndeliveredCallback = async () =>
+			{
+				TestEventRepository.Append_MarkedUndeliveredCallback = null;
+
+				if (beforeAppend is not null)
+					await beforeAppend.Invoke();
+
+				// Competing append will succeed and trigger conflict of the first AppendEventsAsync() call
+				await EventRepository.AppendEventsAsync(nameof(TestRoundAggregate), id, new TestWrappedEvent[]
+				{
+					new(1, "b1"),
+					new(2, "b2"),
+					new(3, "b3"),
+				}.Take(appendedEvents));
+			};
+
+			return appendAsync;
+		}
+
+		private async Task Assert_MarkUndeliveredSemaphore_Async(
+			int? started = null,
+			int? got = null,
+			int? undeliveredConflictKept = null,
+			int? conflicted = null,
+			int? ended = null)
+		{
+			if (started.HasValue)
+			{
+				await AssertSemaphoreAsync(
+					TestEventRepository.MarkUndelivered_Started_Semaphore,
+					started.Value,
+					nameof(TestEventRepository.MarkUndelivered_Started_Semaphore));
+			}
+			if (got.HasValue)
+			{
+				await AssertSemaphoreAsync(
+					TestEventRepository.MarkUndelivered_Got_Semaphore,
+					got.Value,
+					nameof(TestEventRepository.MarkUndelivered_Got_Semaphore));
+			}
+			if (undeliveredConflictKept.HasValue)
+			{
+				await AssertSemaphoreAsync(
+					TestEventRepository.MarkUndelivered_UndeliveredConflictKept_Semaphore,
+					undeliveredConflictKept.Value,
+					nameof(TestEventRepository.MarkUndelivered_UndeliveredConflictKept_Semaphore));
+			}
+			if (conflicted.HasValue)
+			{
+				await AssertSemaphoreAsync(
+					TestEventRepository.MarkUndelivered_Conflicted_Semaphore,
+					conflicted.Value,
+					nameof(TestEventRepository.MarkUndelivered_Conflicted_Semaphore));
+			}
+			if (ended.HasValue)
+			{
+				await AssertSemaphoreAsync(
+					TestEventRepository.MarkUndelivered_Ended_Semaphore,
+					ended.Value,
+					nameof(TestEventRepository.MarkUndelivered_Ended_Semaphore));
+			}
+		}
+
+		private async Task AssertSemaphoreAsync(SemaphoreSlim semaphore, int expected, string? name = null)
+		{
+			Guard.MinimumAndNotNull(nameof(expected), expected, 0);
+			if (expected == 0)
+			{
+				(await semaphore.WaitAsync(0))
+					.ShouldBeFalse($"semaphore '{name}' was expected to be '{expected}' but it wasn't");
+			}
+			else
+			{
+				for (var i = 0; i < expected; i++)
+				{
+					(await semaphore.WaitAsync(0))
+						.ShouldBeTrue($"semaphore '{name}' was expected to be '{expected}' but it wasn't");
+				}
+				(await semaphore.WaitAsync(0))
+					.ShouldBeFalse($"semaphore '{name}' was expected to be '{expected}' but it wasn't");
+			}
+		}
+
+		[Fact]
+		public async Task MarkUndeliveredSequenceIdsAsync_AppendConflict_ReturnOnPreviouEqDefault_Async()
+		{
+			// Arrange
+			Func<Task> appendAsync = PrepareAppendWithConflict(1, 1);
+
+			// Act
+			async Task Act()
+			{
+				await appendAsync.Invoke();
+			}
+
+			// Assert
+			await Assert.ThrowsAsync<OptimisticConcurrencyException>(Act);
+			await Assert_MarkUndeliveredSemaphore_Async(
+				started: 2,
+				undeliveredConflictKept: 0,
+				ended: 0);
+			var events = await EventRepository.ListEventsAsync(nameof(TestRoundAggregate), ID_1);
+			events.Count.ShouldBe(1);
+			var undeliveredEvents = await EventRepository.ListUndeliveredEventsAsync();
+			undeliveredEvents.Count.ShouldBe(1);
+			undeliveredEvents[0].WrappedEvents.Count.ShouldBe(1);
+		}
+
+		[Fact]
+		public async Task MarkUndeliveredSequenceIdsAsync_AppendConflict_UndeliveredConflictKept_Async()
+		{
+			// Arrange
+			Func<Task> appendAsync = PrepareAppendWithConflict(2, 1);
+
+			// Act
+			async Task Act()
+			{
+				await appendAsync.Invoke();
+			}
+
+			// Assert
+			await Assert.ThrowsAsync<OptimisticConcurrencyException>(Act);
+			await Assert_MarkUndeliveredSemaphore_Async(
+				undeliveredConflictKept: 1,
+				ended: 0);
+			var events = await EventRepository.ListEventsAsync(nameof(TestRoundAggregate), ID_1);
+			events.Count.ShouldBe(1);
+			var undeliveredEvents = await EventRepository.ListUndeliveredEventsAsync();
+			undeliveredEvents.Count.ShouldBe(1);
+			undeliveredEvents[0].WrappedEvents.Count.ShouldBe(1);
+		}
+
+		[Fact]
+		public async Task MarkUndeliveredSequenceIdsAsync_AppendConflict_Updated_Async()
+		{
+			// Arrange
+			Func<Task> appendAsync = PrepareAppendWithConflict(1, 2);
+
+			// Act
+			async Task Act()
+			{
+				await appendAsync.Invoke();
+			}
+
+			// Assert
+			await Assert.ThrowsAsync<OptimisticConcurrencyException>(Act);
+			await Assert_MarkUndeliveredSemaphore_Async(
+				conflicted: 0,
+				ended: 1);
+			var events = await EventRepository.ListEventsAsync(nameof(TestRoundAggregate), ID_1);
+			events.Count.ShouldBe(2);
+			var undeliveredEvents = await EventRepository.ListUndeliveredEventsAsync();
+			undeliveredEvents.Count.ShouldBe(1);
+			undeliveredEvents[0].WrappedEvents.Count.ShouldBe(2);
+		}
+
+		[Fact]
+		public async Task MarkUndeliveredSequenceIdsAsync_AppendConflict_Conflicted_Async()
+		{
+			// Arrange
+			Func<Task> appendAsync = PrepareAppendWithConflict(1, 3,
+				() =>
+				{
+					TestEventRepository.MarkUndelivered_Got_Callback = async () =>
+					{
+						TestEventRepository.MarkUndelivered_Got_Callback = null;
+
+						TestEventRepository.Append_MarkedUndeliveredCallback = () =>
+						{
+							TestEventRepository.Append_MarkedUndeliveredCallback = null;
+
+							throw new TestException();
+						};
+
+						await Assert.ThrowsAsync<TestException>(async () => await EventRepository.AppendEventsAsync(nameof(TestRoundAggregate), "ID_1", new TestWrappedEvent[]
+						{
+							new(1, "c1"),
+							new(2, "c2"),
+						}));
+					};
+					return Task.CompletedTask;
+				});
+
+			// Act
+			async Task Act()
+			{
+				await appendAsync.Invoke();
+			}
+
+			// Assert
+			await Assert.ThrowsAsync<OptimisticConcurrencyException>(Act);
+			await Assert_MarkUndeliveredSemaphore_Async(
+				conflicted: 1,
+				ended: 2);
+			var events = await EventRepository.ListEventsAsync(nameof(TestRoundAggregate), ID_1);
+			events.Count.ShouldBe(3);
+			var undeliveredEvents = await EventRepository.ListUndeliveredEventsAsync();
+			undeliveredEvents.Count.ShouldBe(1);
+			undeliveredEvents[0].WrappedEvents.Count.ShouldBe(3);
+		}
+
 		[Theory]
 		[InlineData(2, 1, 1, false, false)]
 		[InlineData(3, 2, 1, true, false)]
 		[InlineData(4, 2, 1, true, true)]
 		[InlineData(3, 1, 1, false, true)]
 		public async Task MarkUndeliveredSequenceIds_TryFixUndeliveredSequenceIdsAfterAppendConflict_RemoveUpdate_Async(
-			int conflictedEvents,
-			int appendedEvents,
-			int confirmedSequenceId,
-			bool updateInTryFix,
-			bool conflictInTryFix)
+		int conflictedEvents,
+		int appendedEvents,
+		int confirmedSequenceId,
+		bool updateInTryFix,
+		bool conflictInTryFix)
 		{
 			// Arrange
 
@@ -748,10 +971,10 @@ namespace WalletWasabi.Tests.UnitTests.EventSourcing
 				(await TestEventRepository.TryFixUndelivered_RemovedSemaphore.WaitAsync(0))
 					.ShouldBe(!updateInTryFix);
 			}
-			(await EventRepository.ListUndeliveredEventsAsync())
-				.SelectMany(a => a.WrappedEvents)
-				.Count()
-				.ShouldBe(appendedEvents - confirmedSequenceId);
+		(await EventRepository.ListUndeliveredEventsAsync())
+			.SelectMany(a => a.WrappedEvents)
+			.Count()
+			.ShouldBe(appendedEvents - confirmedSequenceId);
 		}
 
 		[Theory]

--- a/WalletWasabi.Tests/UnitTests/EventSourcing/TestDomain/TestInMemoryEventRepository.cs
+++ b/WalletWasabi.Tests/UnitTests/EventSourcing/TestDomain/TestInMemoryEventRepository.cs
@@ -1,4 +1,5 @@
 using System.Threading;
+using System.Threading.Tasks;
 using WalletWasabi.EventSourcing;
 using Xunit.Abstractions;
 
@@ -20,93 +21,113 @@ namespace WalletWasabi.Tests.UnitTests.EventSourcing.TestDomain
 
 		public SemaphoreSlim DoMarkDelivered_UndeliveredConflictFixedSemaphore { get; } = new(0);
 
+		public SemaphoreSlim TryFixUndelivered_DetectedSemaphore { get; } = new(0);
 		public SemaphoreSlim TryFixUndelivered_UpdatedSemaphore { get; } = new(0);
 		public SemaphoreSlim TryFixUndelivered_UpdateConflictedSemaphore { get; } = new(0);
 		public SemaphoreSlim TryFixUndelivered_RemovedSemaphore { get; } = new(0);
 		public SemaphoreSlim TryFixUndelivered_RemoveConflictedSemaphore { get; } = new(0);
 
-		public Action? Append_ValidatedCallback { get; set; }
-		public Action? Append_MarkedUndeliveredCallback { get; set; }
-		public Action? Append_ConflictedCallback { get; set; }
-		public Action? Append_AppendedCallback { get; set; }
+		public Func<Task>? Append_ValidatedCallback { get; set; }
+		public Func<Task>? Append_MarkedUndeliveredCallback { get; set; }
+		public Func<Task>? Append_ConflictedCallback { get; set; }
+		public Func<Task>? Append_AppendedCallback { get; set; }
 
-		public Action? DoMarkDelivered_UndeliveredConflictFixedCallback { get; set; }
+		public Func<Task>? DoMarkDelivered_UndeliveredConflictFixedCallback { get; set; }
 
-		public Action? TryFixUndelivered_UpdatedCallback { get; set; }
-		public Action? TryFixUndelivered_UpdateConflictedCallback { get; set; }
-		public Action? TryFixUndelivered_RemovedCallback { get; set; }
-		public Action? TryFixUndelivered_RemoveConflictedCallback { get; set; }
+		public Func<Task>? TryFixUndelivered_DetectedCallback { get; set; }
+		public Func<Task>? TryFixUndelivered_UpdatedCallback { get; set; }
+		public Func<Task>? TryFixUndelivered_UpdateConflictedCallback { get; set; }
+		public Func<Task>? TryFixUndelivered_RemovedCallback { get; set; }
+		public Func<Task>? TryFixUndelivered_RemoveConflictedCallback { get; set; }
 
-		protected override void Append_Validated()
+		protected override async Task Append_Validated()
 		{
-			base.Append_Validated();
+			await base.Append_Validated();
 			Output.WriteLine(nameof(Append_Validated));
 			Append_ValidatedSemaphore.Release();
-			Append_ValidatedCallback?.Invoke();
+			if (Append_ValidatedCallback is not null)
+				await Append_ValidatedCallback.Invoke();
 		}
 
-		protected override void Append_MarkedUndelivered()
+		protected override async Task Append_MarkedUndelivered()
 		{
-			base.Append_MarkedUndelivered();
+			await base.Append_MarkedUndelivered();
 			Output.WriteLine(nameof(Append_MarkedUndelivered));
 			Append_MarkedUndeliveredSemaphore.Release();
-			Append_MarkedUndeliveredCallback?.Invoke();
+			if (Append_MarkedUndeliveredCallback is not null)
+				await Append_MarkedUndeliveredCallback.Invoke();
 		}
 
-		protected override void Append_Conflicted()
+		protected override async Task Append_Conflicted()
 		{
-			base.Append_Conflicted();
+			await base.Append_Conflicted();
 			Output.WriteLine(nameof(Append_Conflicted));
 			Append_ConflictedSemaphore.Release();
-			Append_ConflictedCallback?.Invoke();
+			if (Append_ConflictedCallback is not null)
+				await Append_ConflictedCallback.Invoke();
 		}
 
-		protected override void Append_Appended()
+		protected override async Task Append_Appended()
 		{
-			base.Append_Appended();
+			await base.Append_Appended();
 			Output.WriteLine(nameof(Append_Appended));
 			Append_AppendedSemaphore.Release();
-			Append_AppendedCallback?.Invoke();
+			if (Append_AppendedCallback is not null)
+				await Append_AppendedCallback.Invoke();
 		}
 
-		protected override void DoMarkDelivered_UndeliveredConflictFixed()
+		protected override async Task DoMarkDelivered_UndeliveredConflictFixed()
 		{
-			base.DoMarkDelivered_UndeliveredConflictFixed();
+			await base.DoMarkDelivered_UndeliveredConflictFixed();
 			Output.WriteLine(nameof(DoMarkDelivered_UndeliveredConflictFixed));
 			DoMarkDelivered_UndeliveredConflictFixedSemaphore.Release();
-			DoMarkDelivered_UndeliveredConflictFixedCallback?.Invoke();
+			if (DoMarkDelivered_UndeliveredConflictFixedCallback is not null)
+				await DoMarkDelivered_UndeliveredConflictFixedCallback.Invoke();
 		}
 
-		protected override void TryFixUndelivered_Updated()
+		protected override async Task TryFixUndelivered_Detected()
 		{
-			base.TryFixUndelivered_Updated();
+			await base.TryFixUndelivered_Detected();
+			Output.WriteLine(nameof(TryFixUndelivered_Detected));
+			TryFixUndelivered_DetectedSemaphore.Release();
+			if (TryFixUndelivered_DetectedCallback is not null)
+				await TryFixUndelivered_DetectedCallback.Invoke();
+		}
+
+		protected override async Task TryFixUndelivered_Updated()
+		{
+			await base.TryFixUndelivered_Updated();
 			Output.WriteLine(nameof(TryFixUndelivered_Updated));
 			TryFixUndelivered_UpdatedSemaphore.Release();
-			TryFixUndelivered_UpdatedCallback?.Invoke();
+			if (TryFixUndelivered_UpdatedCallback is not null)
+				await TryFixUndelivered_UpdatedCallback.Invoke();
 		}
 
-		protected override void TryFixUndelivered_UpdateConflicted()
+		protected override async Task TryFixUndelivered_UpdateConflicted()
 		{
-			base.TryFixUndelivered_UpdateConflicted();
+			await base.TryFixUndelivered_UpdateConflicted();
 			Output.WriteLine(nameof(TryFixUndelivered_UpdateConflicted));
 			TryFixUndelivered_UpdateConflictedSemaphore.Release();
-			TryFixUndelivered_UpdateConflictedCallback?.Invoke();
+			if (TryFixUndelivered_UpdateConflictedCallback is not null)
+				await TryFixUndelivered_UpdateConflictedCallback.Invoke();
 		}
 
-		protected override void TryFixUndelivered_Removed()
+		protected override async Task TryFixUndelivered_Removed()
 		{
-			base.TryFixUndelivered_Removed();
+			await base.TryFixUndelivered_Removed();
 			Output.WriteLine(nameof(TryFixUndelivered_Removed));
 			TryFixUndelivered_RemovedSemaphore.Release();
-			TryFixUndelivered_RemovedCallback?.Invoke();
+			if (TryFixUndelivered_RemovedCallback is not null)
+				await TryFixUndelivered_RemovedCallback.Invoke();
 		}
 
-		protected override void TryFixUndelivered_RemoveConflicted()
+		protected override async Task TryFixUndelivered_RemoveConflicted()
 		{
-			base.TryFixUndelivered_RemoveConflicted();
+			await base.TryFixUndelivered_RemoveConflicted();
 			Output.WriteLine(nameof(TryFixUndelivered_RemoveConflicted));
 			TryFixUndelivered_RemoveConflictedSemaphore.Release();
-			TryFixUndelivered_RemoveConflictedCallback?.Invoke();
+			if (TryFixUndelivered_RemoveConflictedCallback is not null)
+				await TryFixUndelivered_RemoveConflictedCallback.Invoke();
 		}
 
 		public void Dispose()
@@ -125,11 +146,13 @@ namespace WalletWasabi.Tests.UnitTests.EventSourcing.TestDomain
 
 			DoMarkDelivered_UndeliveredConflictFixedCallback = null;
 
+			TryFixUndelivered_DetectedSemaphore.Dispose();
 			TryFixUndelivered_UpdatedSemaphore.Dispose();
 			TryFixUndelivered_UpdateConflictedSemaphore.Dispose();
 			TryFixUndelivered_RemovedSemaphore.Dispose();
 			TryFixUndelivered_RemoveConflictedSemaphore.Dispose();
 
+			TryFixUndelivered_DetectedCallback = null;
 			TryFixUndelivered_UpdatedCallback = null;
 			TryFixUndelivered_UpdateConflictedCallback = null;
 			TryFixUndelivered_RemovedCallback = null;

--- a/WalletWasabi.Tests/UnitTests/EventSourcing/TestDomain/TestInMemoryEventRepository.cs
+++ b/WalletWasabi.Tests/UnitTests/EventSourcing/TestDomain/TestInMemoryEventRepository.cs
@@ -61,6 +61,11 @@ namespace WalletWasabi.Tests.UnitTests.EventSourcing.TestDomain
 			Append_MarkedUndeliveredSemaphore.Dispose();
 			Append_ConflictedSemaphore.Dispose();
 			Append_AppendedSemaphore.Dispose();
+
+			Append_ValidatedCallback = null;
+			Append_MarkedUndeliveredCallback = null;
+			Append_ConflictedCallback = null;
+			Append_AppendedCallback = null;
 		}
 	}
 }

--- a/WalletWasabi.Tests/UnitTests/EventSourcing/TestDomain/TestInMemoryEventRepository.cs
+++ b/WalletWasabi.Tests/UnitTests/EventSourcing/TestDomain/TestInMemoryEventRepository.cs
@@ -13,43 +13,54 @@ namespace WalletWasabi.Tests.UnitTests.EventSourcing.TestDomain
 
 		protected ITestOutputHelper Output { get; init; }
 
-		public SemaphoreSlim ValidatedSemaphore { get; } = new(0);
-		public SemaphoreSlim ConflictedSemaphore { get; } = new(0);
-		public SemaphoreSlim AppendedSemaphore { get; } = new(0);
+		public SemaphoreSlim Append_ValidatedSemaphore { get; } = new(0);
+		public SemaphoreSlim Append_MarkedUndeliveredSemaphore { get; } = new(0);
+		public SemaphoreSlim Append_ConflictedSemaphore { get; } = new(0);
+		public SemaphoreSlim Append_AppendedSemaphore { get; } = new(0);
 
-		public Action? ValidatedCallback { get; set; }
-		public Action? ConflictedCallback { get; set; }
-		public Action? AppendedCallback { get; set; }
+		public Action? Append_ValidatedCallback { get; set; }
+		public Action? Append_MarkedUndeliveredCallback { get; set; }
+		public Action? Append_ConflictedCallback { get; set; }
+		public Action? Append_AppendedCallback { get; set; }
 
 		protected override void Append_Validated()
 		{
 			base.Append_Validated();
 			Output.WriteLine(nameof(Append_Validated));
-			ValidatedSemaphore.Release();
-			ValidatedCallback?.Invoke();
+			Append_ValidatedSemaphore.Release();
+			Append_ValidatedCallback?.Invoke();
+		}
+
+		protected override void Append_MarkedUndelivered()
+		{
+			base.Append_MarkedUndelivered();
+			Output.WriteLine(nameof(Append_MarkedUndelivered));
+			Append_MarkedUndeliveredSemaphore.Release();
+			Append_MarkedUndeliveredCallback?.Invoke();
 		}
 
 		protected override void Append_Conflicted()
 		{
 			base.Append_Conflicted();
 			Output.WriteLine(nameof(Append_Conflicted));
-			ConflictedSemaphore.Release();
-			ConflictedCallback?.Invoke();
+			Append_ConflictedSemaphore.Release();
+			Append_ConflictedCallback?.Invoke();
 		}
 
 		protected override void Append_Appended()
 		{
 			base.Append_Appended();
 			Output.WriteLine(nameof(Append_Appended));
-			AppendedSemaphore.Release();
-			AppendedCallback?.Invoke();
+			Append_AppendedSemaphore.Release();
+			Append_AppendedCallback?.Invoke();
 		}
 
 		public void Dispose()
 		{
-			ValidatedSemaphore.Dispose();
-			ConflictedSemaphore.Dispose();
-			AppendedSemaphore.Dispose();
+			Append_ValidatedSemaphore.Dispose();
+			Append_MarkedUndeliveredSemaphore.Dispose();
+			Append_ConflictedSemaphore.Dispose();
+			Append_AppendedSemaphore.Dispose();
 		}
 	}
 }

--- a/WalletWasabi.Tests/UnitTests/EventSourcing/TestDomain/TestInMemoryEventRepository.cs
+++ b/WalletWasabi.Tests/UnitTests/EventSourcing/TestDomain/TestInMemoryEventRepository.cs
@@ -18,10 +18,24 @@ namespace WalletWasabi.Tests.UnitTests.EventSourcing.TestDomain
 		public SemaphoreSlim Append_ConflictedSemaphore { get; } = new(0);
 		public SemaphoreSlim Append_AppendedSemaphore { get; } = new(0);
 
+		public SemaphoreSlim DoMarkDelivered_UndeliveredConflictFixedSemaphore { get; } = new(0);
+
+		public SemaphoreSlim TryFixUndelivered_UpdatedSemaphore { get; } = new(0);
+		public SemaphoreSlim TryFixUndelivered_UpdateConflictedSemaphore { get; } = new(0);
+		public SemaphoreSlim TryFixUndelivered_RemovedSemaphore { get; } = new(0);
+		public SemaphoreSlim TryFixUndelivered_RemoveConflictedSemaphore { get; } = new(0);
+
 		public Action? Append_ValidatedCallback { get; set; }
 		public Action? Append_MarkedUndeliveredCallback { get; set; }
 		public Action? Append_ConflictedCallback { get; set; }
 		public Action? Append_AppendedCallback { get; set; }
+
+		public Action? DoMarkDelivered_UndeliveredConflictFixedCallback { get; set; }
+
+		public Action? TryFixUndelivered_UpdatedCallback { get; set; }
+		public Action? TryFixUndelivered_UpdateConflictedCallback { get; set; }
+		public Action? TryFixUndelivered_RemovedCallback { get; set; }
+		public Action? TryFixUndelivered_RemoveConflictedCallback { get; set; }
 
 		protected override void Append_Validated()
 		{
@@ -55,6 +69,46 @@ namespace WalletWasabi.Tests.UnitTests.EventSourcing.TestDomain
 			Append_AppendedCallback?.Invoke();
 		}
 
+		protected override void DoMarkDelivered_UndeliveredConflictFixed()
+		{
+			base.DoMarkDelivered_UndeliveredConflictFixed();
+			Output.WriteLine(nameof(DoMarkDelivered_UndeliveredConflictFixed));
+			DoMarkDelivered_UndeliveredConflictFixedSemaphore.Release();
+			DoMarkDelivered_UndeliveredConflictFixedCallback?.Invoke();
+		}
+
+		protected override void TryFixUndelivered_Updated()
+		{
+			base.TryFixUndelivered_Updated();
+			Output.WriteLine(nameof(TryFixUndelivered_Updated));
+			TryFixUndelivered_UpdatedSemaphore.Release();
+			TryFixUndelivered_UpdatedCallback?.Invoke();
+		}
+
+		protected override void TryFixUndelivered_UpdateConflicted()
+		{
+			base.TryFixUndelivered_UpdateConflicted();
+			Output.WriteLine(nameof(TryFixUndelivered_UpdateConflicted));
+			TryFixUndelivered_UpdateConflictedSemaphore.Release();
+			TryFixUndelivered_UpdateConflictedCallback?.Invoke();
+		}
+
+		protected override void TryFixUndelivered_Removed()
+		{
+			base.TryFixUndelivered_Removed();
+			Output.WriteLine(nameof(TryFixUndelivered_Removed));
+			TryFixUndelivered_RemovedSemaphore.Release();
+			TryFixUndelivered_RemovedCallback?.Invoke();
+		}
+
+		protected override void TryFixUndelivered_RemoveConflicted()
+		{
+			base.TryFixUndelivered_RemoveConflicted();
+			Output.WriteLine(nameof(TryFixUndelivered_RemoveConflicted));
+			TryFixUndelivered_RemoveConflictedSemaphore.Release();
+			TryFixUndelivered_RemoveConflictedCallback?.Invoke();
+		}
+
 		public void Dispose()
 		{
 			Append_ValidatedSemaphore.Dispose();
@@ -66,6 +120,20 @@ namespace WalletWasabi.Tests.UnitTests.EventSourcing.TestDomain
 			Append_MarkedUndeliveredCallback = null;
 			Append_ConflictedCallback = null;
 			Append_AppendedCallback = null;
+
+			DoMarkDelivered_UndeliveredConflictFixedSemaphore.Dispose();
+
+			DoMarkDelivered_UndeliveredConflictFixedCallback = null;
+
+			TryFixUndelivered_UpdatedSemaphore.Dispose();
+			TryFixUndelivered_UpdateConflictedSemaphore.Dispose();
+			TryFixUndelivered_RemovedSemaphore.Dispose();
+			TryFixUndelivered_RemoveConflictedSemaphore.Dispose();
+
+			TryFixUndelivered_UpdatedCallback = null;
+			TryFixUndelivered_UpdateConflictedCallback = null;
+			TryFixUndelivered_RemovedCallback = null;
+			TryFixUndelivered_RemoveConflictedCallback = null;
 		}
 	}
 }

--- a/WalletWasabi.Tests/UnitTests/EventSourcing/TestDomain/TestInMemoryEventRepository.cs
+++ b/WalletWasabi.Tests/UnitTests/EventSourcing/TestDomain/TestInMemoryEventRepository.cs
@@ -21,26 +21,26 @@ namespace WalletWasabi.Tests.UnitTests.EventSourcing.TestDomain
 		public Action? ConflictedCallback { get; set; }
 		public Action? AppendedCallback { get; set; }
 
-		protected override void Validated()
+		protected override void Append_Validated()
 		{
-			base.Validated();
-			Output.WriteLine(nameof(Validated));
+			base.Append_Validated();
+			Output.WriteLine(nameof(Append_Validated));
 			ValidatedSemaphore.Release();
 			ValidatedCallback?.Invoke();
 		}
 
-		protected override void Conflicted()
+		protected override void Append_Conflicted()
 		{
-			base.Conflicted();
-			Output.WriteLine(nameof(Conflicted));
+			base.Append_Conflicted();
+			Output.WriteLine(nameof(Append_Conflicted));
 			ConflictedSemaphore.Release();
 			ConflictedCallback?.Invoke();
 		}
 
-		protected override void Appended()
+		protected override void Append_Appended()
 		{
-			base.Appended();
-			Output.WriteLine(nameof(Appended));
+			base.Append_Appended();
+			Output.WriteLine(nameof(Append_Appended));
 			AppendedSemaphore.Release();
 			AppendedCallback?.Invoke();
 		}

--- a/WalletWasabi.Tests/UnitTests/EventSourcing/TestDomain/TestInMemoryEventRepository.cs
+++ b/WalletWasabi.Tests/UnitTests/EventSourcing/TestDomain/TestInMemoryEventRepository.cs
@@ -19,6 +19,12 @@ namespace WalletWasabi.Tests.UnitTests.EventSourcing.TestDomain
 		public SemaphoreSlim Append_ConflictedSemaphore { get; } = new(0);
 		public SemaphoreSlim Append_AppendedSemaphore { get; } = new(0);
 
+		public SemaphoreSlim MarkUndelivered_Started_Semaphore { get; } = new(0);
+		public SemaphoreSlim MarkUndelivered_Got_Semaphore { get; } = new(0);
+		public SemaphoreSlim MarkUndelivered_UndeliveredConflictKept_Semaphore { get; } = new(0);
+		public SemaphoreSlim MarkUndelivered_Conflicted_Semaphore { get; } = new(0);
+		public SemaphoreSlim MarkUndelivered_Ended_Semaphore { get; } = new(0);
+
 		public SemaphoreSlim DoMarkDelivered_UndeliveredConflictFixedSemaphore { get; } = new(0);
 
 		public SemaphoreSlim TryFixUndelivered_DetectedSemaphore { get; } = new(0);
@@ -31,6 +37,12 @@ namespace WalletWasabi.Tests.UnitTests.EventSourcing.TestDomain
 		public Func<Task>? Append_MarkedUndeliveredCallback { get; set; }
 		public Func<Task>? Append_ConflictedCallback { get; set; }
 		public Func<Task>? Append_AppendedCallback { get; set; }
+
+		public Func<Task>? MarkUndelivered_Started_Callback { get; set; }
+		public Func<Task>? MarkUndelivered_Got_Callback { get; set; }
+		public Func<Task>? MarkUndelivered_UndeliveredConflictKept_Callback { get; set; }
+		public Func<Task>? MarkUndelivered_Conflicted_Callback { get; set; }
+		public Func<Task>? MarkUndelivered_Ended_Callback { get; set; }
 
 		public Func<Task>? DoMarkDelivered_UndeliveredConflictFixedCallback { get; set; }
 
@@ -74,6 +86,51 @@ namespace WalletWasabi.Tests.UnitTests.EventSourcing.TestDomain
 			Append_AppendedSemaphore.Release();
 			if (Append_AppendedCallback is not null)
 				await Append_AppendedCallback.Invoke();
+		}
+
+		protected override async Task MarkUndelivered_Started()
+		{
+			await base.MarkUndelivered_Started();
+			Output.WriteLine(nameof(MarkUndelivered_Started));
+			MarkUndelivered_Started_Semaphore.Release();
+			if (MarkUndelivered_Started_Callback is not null)
+				await MarkUndelivered_Started_Callback.Invoke();
+		}
+
+		protected override async Task MarkUndelivered_Got()
+		{
+			await base.MarkUndelivered_Got();
+			Output.WriteLine(nameof(MarkUndelivered_Got));
+			MarkUndelivered_Got_Semaphore.Release();
+			if (MarkUndelivered_Got_Callback is not null)
+				await MarkUndelivered_Got_Callback.Invoke();
+		}
+
+		protected override async Task MarkUndelivered_UndeliveredConflictKept()
+		{
+			await base.MarkUndelivered_UndeliveredConflictKept();
+			Output.WriteLine(nameof(MarkUndelivered_UndeliveredConflictKept));
+			MarkUndelivered_UndeliveredConflictKept_Semaphore.Release();
+			if (MarkUndelivered_UndeliveredConflictKept_Callback is not null)
+				await MarkUndelivered_UndeliveredConflictKept_Callback.Invoke();
+		}
+
+		protected override async Task MarkUndelivered_Conflicted()
+		{
+			await base.MarkUndelivered_Conflicted();
+			Output.WriteLine(nameof(MarkUndelivered_Conflicted));
+			MarkUndelivered_Conflicted_Semaphore.Release();
+			if (MarkUndelivered_Conflicted_Callback is not null)
+				await MarkUndelivered_Conflicted_Callback.Invoke();
+		}
+
+		protected override async Task MarkUndelivered_Ended()
+		{
+			await base.MarkUndelivered_Ended();
+			Output.WriteLine(nameof(MarkUndelivered_Ended));
+			MarkUndelivered_Ended_Semaphore.Release();
+			if (MarkUndelivered_Ended_Callback is not null)
+				await MarkUndelivered_Ended_Callback.Invoke();
 		}
 
 		protected override async Task DoMarkDelivered_UndeliveredConflictFixed()
@@ -141,6 +198,18 @@ namespace WalletWasabi.Tests.UnitTests.EventSourcing.TestDomain
 			Append_MarkedUndeliveredCallback = null;
 			Append_ConflictedCallback = null;
 			Append_AppendedCallback = null;
+
+			MarkUndelivered_Started_Semaphore.Dispose();
+			MarkUndelivered_Got_Semaphore.Dispose();
+			MarkUndelivered_UndeliveredConflictKept_Semaphore.Dispose();
+			MarkUndelivered_Conflicted_Semaphore.Dispose();
+			MarkUndelivered_Ended_Semaphore.Dispose();
+
+			MarkUndelivered_Started_Callback = null;
+			MarkUndelivered_Got_Callback = null;
+			MarkUndelivered_UndeliveredConflictKept_Callback = null;
+			MarkUndelivered_Conflicted_Callback = null;
+			MarkUndelivered_Ended_Callback = null;
 
 			DoMarkDelivered_UndeliveredConflictFixedSemaphore.Dispose();
 

--- a/WalletWasabi.Tests/UnitTests/EventSourcing/TestDomain/TestInMemoryEventRepository.cs
+++ b/WalletWasabi.Tests/UnitTests/EventSourcing/TestDomain/TestInMemoryEventRepository.cs
@@ -25,13 +25,12 @@ namespace WalletWasabi.Tests.UnitTests.EventSourcing.TestDomain
 		public SemaphoreSlim MarkUndelivered_Conflicted_Semaphore { get; } = new(0);
 		public SemaphoreSlim MarkUndelivered_Ended_Semaphore { get; } = new(0);
 
-		public SemaphoreSlim DoMarkDelivered_UndeliveredConflictFixedSemaphore { get; } = new(0);
+		public SemaphoreSlim MarkDelivered_Started_Semaphore { get; } = new(0);
+		public SemaphoreSlim MarkDelivered_Got_Semaphore { get; } = new(0);
+		public SemaphoreSlim MarkDelivered_Conflicted_Semaphore { get; } = new(0);
+		public SemaphoreSlim MarkDelivered_Ended_Semaphore { get; } = new(0);
 
-		public SemaphoreSlim TryFixUndelivered_DetectedSemaphore { get; } = new(0);
-		public SemaphoreSlim TryFixUndelivered_UpdatedSemaphore { get; } = new(0);
-		public SemaphoreSlim TryFixUndelivered_UpdateConflictedSemaphore { get; } = new(0);
-		public SemaphoreSlim TryFixUndelivered_RemovedSemaphore { get; } = new(0);
-		public SemaphoreSlim TryFixUndelivered_RemoveConflictedSemaphore { get; } = new(0);
+		public SemaphoreSlim DoMarkDelivered_UndeliveredConflictFixedSemaphore { get; } = new(0);
 
 		public Func<Task>? Append_ValidatedCallback { get; set; }
 		public Func<Task>? Append_MarkedUndeliveredCallback { get; set; }
@@ -44,13 +43,12 @@ namespace WalletWasabi.Tests.UnitTests.EventSourcing.TestDomain
 		public Func<Task>? MarkUndelivered_Conflicted_Callback { get; set; }
 		public Func<Task>? MarkUndelivered_Ended_Callback { get; set; }
 
-		public Func<Task>? DoMarkDelivered_UndeliveredConflictFixedCallback { get; set; }
+		public Func<Task>? MarkDelivered_Started_Callback { get; set; }
+		public Func<Task>? MarkDelivered_Got_Callback { get; set; }
+		public Func<Task>? MarkDelivered_Conflicted_Callback { get; set; }
+		public Func<Task>? MarkDelivered_Ended_Callback { get; set; }
 
-		public Func<Task>? TryFixUndelivered_DetectedCallback { get; set; }
-		public Func<Task>? TryFixUndelivered_UpdatedCallback { get; set; }
-		public Func<Task>? TryFixUndelivered_UpdateConflictedCallback { get; set; }
-		public Func<Task>? TryFixUndelivered_RemovedCallback { get; set; }
-		public Func<Task>? TryFixUndelivered_RemoveConflictedCallback { get; set; }
+		public Func<Task>? DoMarkDelivered_UndeliveredConflictFixedCallback { get; set; }
 
 		protected override async Task Append_Validated()
 		{
@@ -133,6 +131,42 @@ namespace WalletWasabi.Tests.UnitTests.EventSourcing.TestDomain
 				await MarkUndelivered_Ended_Callback.Invoke();
 		}
 
+		protected override async Task MarkDelivered_Started()
+		{
+			await base.MarkDelivered_Started();
+			Output.WriteLine(nameof(MarkDelivered_Started));
+			MarkDelivered_Started_Semaphore.Release();
+			if (MarkDelivered_Started_Callback is not null)
+				await MarkDelivered_Started_Callback.Invoke();
+		}
+
+		protected override async Task MarkDelivered_Got()
+		{
+			await base.MarkDelivered_Got();
+			Output.WriteLine(nameof(MarkDelivered_Got));
+			MarkDelivered_Got_Semaphore.Release();
+			if (MarkDelivered_Got_Callback is not null)
+				await MarkDelivered_Got_Callback.Invoke();
+		}
+
+		protected override async Task MarkDelivered_Conflicted()
+		{
+			await base.MarkDelivered_Conflicted();
+			Output.WriteLine(nameof(MarkDelivered_Conflicted));
+			MarkDelivered_Conflicted_Semaphore.Release();
+			if (MarkDelivered_Conflicted_Callback is not null)
+				await MarkDelivered_Conflicted_Callback.Invoke();
+		}
+
+		protected override async Task MarkDelivered_Ended()
+		{
+			await base.MarkDelivered_Ended();
+			Output.WriteLine(nameof(MarkDelivered_Ended));
+			MarkDelivered_Ended_Semaphore.Release();
+			if (MarkDelivered_Ended_Callback is not null)
+				await MarkDelivered_Ended_Callback.Invoke();
+		}
+
 		protected override async Task DoMarkDelivered_UndeliveredConflictFixed()
 		{
 			await base.DoMarkDelivered_UndeliveredConflictFixed();
@@ -140,51 +174,6 @@ namespace WalletWasabi.Tests.UnitTests.EventSourcing.TestDomain
 			DoMarkDelivered_UndeliveredConflictFixedSemaphore.Release();
 			if (DoMarkDelivered_UndeliveredConflictFixedCallback is not null)
 				await DoMarkDelivered_UndeliveredConflictFixedCallback.Invoke();
-		}
-
-		protected override async Task TryFixUndelivered_Detected()
-		{
-			await base.TryFixUndelivered_Detected();
-			Output.WriteLine(nameof(TryFixUndelivered_Detected));
-			TryFixUndelivered_DetectedSemaphore.Release();
-			if (TryFixUndelivered_DetectedCallback is not null)
-				await TryFixUndelivered_DetectedCallback.Invoke();
-		}
-
-		protected override async Task TryFixUndelivered_Updated()
-		{
-			await base.TryFixUndelivered_Updated();
-			Output.WriteLine(nameof(TryFixUndelivered_Updated));
-			TryFixUndelivered_UpdatedSemaphore.Release();
-			if (TryFixUndelivered_UpdatedCallback is not null)
-				await TryFixUndelivered_UpdatedCallback.Invoke();
-		}
-
-		protected override async Task TryFixUndelivered_UpdateConflicted()
-		{
-			await base.TryFixUndelivered_UpdateConflicted();
-			Output.WriteLine(nameof(TryFixUndelivered_UpdateConflicted));
-			TryFixUndelivered_UpdateConflictedSemaphore.Release();
-			if (TryFixUndelivered_UpdateConflictedCallback is not null)
-				await TryFixUndelivered_UpdateConflictedCallback.Invoke();
-		}
-
-		protected override async Task TryFixUndelivered_Removed()
-		{
-			await base.TryFixUndelivered_Removed();
-			Output.WriteLine(nameof(TryFixUndelivered_Removed));
-			TryFixUndelivered_RemovedSemaphore.Release();
-			if (TryFixUndelivered_RemovedCallback is not null)
-				await TryFixUndelivered_RemovedCallback.Invoke();
-		}
-
-		protected override async Task TryFixUndelivered_RemoveConflicted()
-		{
-			await base.TryFixUndelivered_RemoveConflicted();
-			Output.WriteLine(nameof(TryFixUndelivered_RemoveConflicted));
-			TryFixUndelivered_RemoveConflictedSemaphore.Release();
-			if (TryFixUndelivered_RemoveConflictedCallback is not null)
-				await TryFixUndelivered_RemoveConflictedCallback.Invoke();
 		}
 
 		public void Dispose()
@@ -211,21 +200,19 @@ namespace WalletWasabi.Tests.UnitTests.EventSourcing.TestDomain
 			MarkUndelivered_Conflicted_Callback = null;
 			MarkUndelivered_Ended_Callback = null;
 
+			MarkDelivered_Started_Semaphore.Dispose();
+			MarkDelivered_Got_Semaphore.Dispose();
+			MarkDelivered_Conflicted_Semaphore.Dispose();
+			MarkDelivered_Ended_Semaphore.Dispose();
+
+			MarkDelivered_Started_Callback = null;
+			MarkDelivered_Got_Callback = null;
+			MarkDelivered_Conflicted_Callback = null;
+			MarkDelivered_Ended_Callback = null;
+
 			DoMarkDelivered_UndeliveredConflictFixedSemaphore.Dispose();
 
 			DoMarkDelivered_UndeliveredConflictFixedCallback = null;
-
-			TryFixUndelivered_DetectedSemaphore.Dispose();
-			TryFixUndelivered_UpdatedSemaphore.Dispose();
-			TryFixUndelivered_UpdateConflictedSemaphore.Dispose();
-			TryFixUndelivered_RemovedSemaphore.Dispose();
-			TryFixUndelivered_RemoveConflictedSemaphore.Dispose();
-
-			TryFixUndelivered_DetectedCallback = null;
-			TryFixUndelivered_UpdatedCallback = null;
-			TryFixUndelivered_UpdateConflictedCallback = null;
-			TryFixUndelivered_RemovedCallback = null;
-			TryFixUndelivered_RemoveConflictedCallback = null;
 		}
 	}
 }

--- a/WalletWasabi.Tests/UnitTests/EventSourcing/TestDomain/TestInMemoryEventRepository.cs
+++ b/WalletWasabi.Tests/UnitTests/EventSourcing/TestDomain/TestInMemoryEventRepository.cs
@@ -14,10 +14,10 @@ namespace WalletWasabi.Tests.UnitTests.EventSourcing.TestDomain
 
 		protected ITestOutputHelper Output { get; init; }
 
-		public SemaphoreSlim Append_ValidatedSemaphore { get; } = new(0);
-		public SemaphoreSlim Append_MarkedUndeliveredSemaphore { get; } = new(0);
-		public SemaphoreSlim Append_ConflictedSemaphore { get; } = new(0);
-		public SemaphoreSlim Append_AppendedSemaphore { get; } = new(0);
+		public SemaphoreSlim Append_Validated_Semaphore { get; } = new(0);
+		public SemaphoreSlim Append_MarkedUndelivered_Semaphore { get; } = new(0);
+		public SemaphoreSlim Append_Conflicted_Semaphore { get; } = new(0);
+		public SemaphoreSlim Append_Appended_Semaphore { get; } = new(0);
 
 		public SemaphoreSlim MarkUndelivered_Started_Semaphore { get; } = new(0);
 		public SemaphoreSlim MarkUndelivered_Got_Semaphore { get; } = new(0);
@@ -26,16 +26,18 @@ namespace WalletWasabi.Tests.UnitTests.EventSourcing.TestDomain
 		public SemaphoreSlim MarkUndelivered_Ended_Semaphore { get; } = new(0);
 
 		public SemaphoreSlim MarkDelivered_Started_Semaphore { get; } = new(0);
-		public SemaphoreSlim MarkDelivered_Got_Semaphore { get; } = new(0);
+		public SemaphoreSlim MarkDelivered_GotAggregateEvents_Semaphore { get; } = new(0);
 		public SemaphoreSlim MarkDelivered_Conflicted_Semaphore { get; } = new(0);
 		public SemaphoreSlim MarkDelivered_Ended_Semaphore { get; } = new(0);
 
-		public SemaphoreSlim DoMarkDelivered_UndeliveredConflictFixedSemaphore { get; } = new(0);
+		public SemaphoreSlim DoMarkDelivered_Entered_Semaphore { get; } = new(0);
+		public SemaphoreSlim DoMarkDelivered_Got_Semaphore { get; } = new(0);
+		public SemaphoreSlim DoMarkDelivered_UndeliveredConflictFixed_Semaphore { get; } = new(0);
 
-		public Func<Task>? Append_ValidatedCallback { get; set; }
-		public Func<Task>? Append_MarkedUndeliveredCallback { get; set; }
-		public Func<Task>? Append_ConflictedCallback { get; set; }
-		public Func<Task>? Append_AppendedCallback { get; set; }
+		public Func<Task>? Append_Validated_Callback { get; set; }
+		public Func<Task>? Append_MarkedUndelivered_Callback { get; set; }
+		public Func<Task>? Append_Conflicted_Callback { get; set; }
+		public Func<Task>? Append_Appended_Callback { get; set; }
 
 		public Func<Task>? MarkUndelivered_Started_Callback { get; set; }
 		public Func<Task>? MarkUndelivered_Got_Callback { get; set; }
@@ -44,46 +46,48 @@ namespace WalletWasabi.Tests.UnitTests.EventSourcing.TestDomain
 		public Func<Task>? MarkUndelivered_Ended_Callback { get; set; }
 
 		public Func<Task>? MarkDelivered_Started_Callback { get; set; }
-		public Func<Task>? MarkDelivered_Got_Callback { get; set; }
+		public Func<Task>? MarkDelivered_GotAggregateEvents_Callback { get; set; }
 		public Func<Task>? MarkDelivered_Conflicted_Callback { get; set; }
 		public Func<Task>? MarkDelivered_Ended_Callback { get; set; }
 
-		public Func<Task>? DoMarkDelivered_UndeliveredConflictFixedCallback { get; set; }
+		public Func<Task>? DoMarkDelivered_Entered_Callback { get; set; }
+		public Func<Task>? DoMarkDelivered_Got_Callback { get; set; }
+		public Func<Task>? DoMarkDelivered_UndeliveredConflictFixed_Callback { get; set; }
 
 		protected override async Task Append_Validated()
 		{
 			await base.Append_Validated();
 			Output.WriteLine(nameof(Append_Validated));
-			Append_ValidatedSemaphore.Release();
-			if (Append_ValidatedCallback is not null)
-				await Append_ValidatedCallback.Invoke();
+			Append_Validated_Semaphore.Release();
+			if (Append_Validated_Callback is not null)
+				await Append_Validated_Callback.Invoke();
 		}
 
 		protected override async Task Append_MarkedUndelivered()
 		{
 			await base.Append_MarkedUndelivered();
 			Output.WriteLine(nameof(Append_MarkedUndelivered));
-			Append_MarkedUndeliveredSemaphore.Release();
-			if (Append_MarkedUndeliveredCallback is not null)
-				await Append_MarkedUndeliveredCallback.Invoke();
+			Append_MarkedUndelivered_Semaphore.Release();
+			if (Append_MarkedUndelivered_Callback is not null)
+				await Append_MarkedUndelivered_Callback.Invoke();
 		}
 
 		protected override async Task Append_Conflicted()
 		{
 			await base.Append_Conflicted();
 			Output.WriteLine(nameof(Append_Conflicted));
-			Append_ConflictedSemaphore.Release();
-			if (Append_ConflictedCallback is not null)
-				await Append_ConflictedCallback.Invoke();
+			Append_Conflicted_Semaphore.Release();
+			if (Append_Conflicted_Callback is not null)
+				await Append_Conflicted_Callback.Invoke();
 		}
 
 		protected override async Task Append_Appended()
 		{
 			await base.Append_Appended();
 			Output.WriteLine(nameof(Append_Appended));
-			Append_AppendedSemaphore.Release();
-			if (Append_AppendedCallback is not null)
-				await Append_AppendedCallback.Invoke();
+			Append_Appended_Semaphore.Release();
+			if (Append_Appended_Callback is not null)
+				await Append_Appended_Callback.Invoke();
 		}
 
 		protected override async Task MarkUndelivered_Started()
@@ -140,13 +144,13 @@ namespace WalletWasabi.Tests.UnitTests.EventSourcing.TestDomain
 				await MarkDelivered_Started_Callback.Invoke();
 		}
 
-		protected override async Task MarkDelivered_Got()
+		protected override async Task MarkDelivered_GotAggregateEvents()
 		{
-			await base.MarkDelivered_Got();
-			Output.WriteLine(nameof(MarkDelivered_Got));
-			MarkDelivered_Got_Semaphore.Release();
-			if (MarkDelivered_Got_Callback is not null)
-				await MarkDelivered_Got_Callback.Invoke();
+			await base.MarkDelivered_GotAggregateEvents();
+			Output.WriteLine(nameof(MarkDelivered_GotAggregateEvents));
+			MarkDelivered_GotAggregateEvents_Semaphore.Release();
+			if (MarkDelivered_GotAggregateEvents_Callback is not null)
+				await MarkDelivered_GotAggregateEvents_Callback.Invoke();
 		}
 
 		protected override async Task MarkDelivered_Conflicted()
@@ -167,26 +171,44 @@ namespace WalletWasabi.Tests.UnitTests.EventSourcing.TestDomain
 				await MarkDelivered_Ended_Callback.Invoke();
 		}
 
+		protected override async Task DoMarkDelivered_Entered()
+		{
+			await base.DoMarkDelivered_Entered();
+			Output.WriteLine(nameof(DoMarkDelivered_Entered));
+			DoMarkDelivered_Entered_Semaphore.Release();
+			if (DoMarkDelivered_Entered_Callback is not null)
+				await DoMarkDelivered_Entered_Callback.Invoke();
+		}
+
+		protected override async Task DoMarkDelivered_Got()
+		{
+			await base.DoMarkDelivered_Got();
+			Output.WriteLine(nameof(DoMarkDelivered_Got));
+			DoMarkDelivered_Got_Semaphore.Release();
+			if (DoMarkDelivered_Got_Callback is not null)
+				await DoMarkDelivered_Got_Callback.Invoke();
+		}
+
 		protected override async Task DoMarkDelivered_UndeliveredConflictFixed()
 		{
 			await base.DoMarkDelivered_UndeliveredConflictFixed();
 			Output.WriteLine(nameof(DoMarkDelivered_UndeliveredConflictFixed));
-			DoMarkDelivered_UndeliveredConflictFixedSemaphore.Release();
-			if (DoMarkDelivered_UndeliveredConflictFixedCallback is not null)
-				await DoMarkDelivered_UndeliveredConflictFixedCallback.Invoke();
+			DoMarkDelivered_UndeliveredConflictFixed_Semaphore.Release();
+			if (DoMarkDelivered_UndeliveredConflictFixed_Callback is not null)
+				await DoMarkDelivered_UndeliveredConflictFixed_Callback.Invoke();
 		}
 
 		public void Dispose()
 		{
-			Append_ValidatedSemaphore.Dispose();
-			Append_MarkedUndeliveredSemaphore.Dispose();
-			Append_ConflictedSemaphore.Dispose();
-			Append_AppendedSemaphore.Dispose();
+			Append_Validated_Semaphore.Dispose();
+			Append_MarkedUndelivered_Semaphore.Dispose();
+			Append_Conflicted_Semaphore.Dispose();
+			Append_Appended_Semaphore.Dispose();
 
-			Append_ValidatedCallback = null;
-			Append_MarkedUndeliveredCallback = null;
-			Append_ConflictedCallback = null;
-			Append_AppendedCallback = null;
+			Append_Validated_Callback = null;
+			Append_MarkedUndelivered_Callback = null;
+			Append_Conflicted_Callback = null;
+			Append_Appended_Callback = null;
 
 			MarkUndelivered_Started_Semaphore.Dispose();
 			MarkUndelivered_Got_Semaphore.Dispose();
@@ -201,18 +223,22 @@ namespace WalletWasabi.Tests.UnitTests.EventSourcing.TestDomain
 			MarkUndelivered_Ended_Callback = null;
 
 			MarkDelivered_Started_Semaphore.Dispose();
-			MarkDelivered_Got_Semaphore.Dispose();
+			MarkDelivered_GotAggregateEvents_Semaphore.Dispose();
 			MarkDelivered_Conflicted_Semaphore.Dispose();
 			MarkDelivered_Ended_Semaphore.Dispose();
 
 			MarkDelivered_Started_Callback = null;
-			MarkDelivered_Got_Callback = null;
+			MarkDelivered_GotAggregateEvents_Callback = null;
 			MarkDelivered_Conflicted_Callback = null;
 			MarkDelivered_Ended_Callback = null;
 
-			DoMarkDelivered_UndeliveredConflictFixedSemaphore.Dispose();
+			DoMarkDelivered_Entered_Semaphore.Dispose();
+			DoMarkDelivered_Got_Semaphore.Dispose();
+			DoMarkDelivered_UndeliveredConflictFixed_Semaphore.Dispose();
 
-			DoMarkDelivered_UndeliveredConflictFixedCallback = null;
+			DoMarkDelivered_Entered_Callback = null;
+			DoMarkDelivered_Got_Callback = null;
+			DoMarkDelivered_UndeliveredConflictFixed_Callback = null;
 		}
 	}
 }

--- a/WalletWasabi.Tests/WalletWasabi.Tests.csproj
+++ b/WalletWasabi.Tests/WalletWasabi.Tests.csproj
@@ -27,6 +27,7 @@
 		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.0.1" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
 		<PackageReference Include="Moq" Version="4.16.1" />
+		<PackageReference Include="Shouldly" Version="4.0.3" />
 		<PackageReference Include="xunit" Version="2.4.1" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
 			<PrivateAssets>all</PrivateAssets>

--- a/WalletWasabi/EventSourcing/InMemoryEventRepository.cs
+++ b/WalletWasabi/EventSourcing/InMemoryEventRepository.cs
@@ -180,7 +180,7 @@ namespace WalletWasabi.EventSourcing
 						nameof(deliveredSequenceId));
 				}
 
-				await MarkDelivered_Got().ConfigureAwait(false); // no action
+				await MarkDelivered_GotAggregateEvents().ConfigureAwait(false); // no action
 
 				conflict = !await TryDoMarkEventsAsDeliveredComulativeAsync(aggregateKey, aggregateEvents, deliveredSequenceId)
 					.ConfigureAwait(false);
@@ -435,7 +435,7 @@ namespace WalletWasabi.EventSourcing
 		}
 
 		// Hook for parallel critical section testing.
-		protected virtual Task MarkDelivered_Got()
+		protected virtual Task MarkDelivered_GotAggregateEvents()
 		{
 			// Keep empty. To be overriden in tests.
 			return Task.CompletedTask;

--- a/WalletWasabi/EventSourcing/InMemoryEventRepository.cs
+++ b/WalletWasabi/EventSourcing/InMemoryEventRepository.cs
@@ -16,6 +16,8 @@ namespace WalletWasabi.EventSourcing
 	/// </summary>
 	public class InMemoryEventRepository : IEventRepository
 	{
+		private const int LIVE_LOCK_LIMIT = 10000;
+
 		private static readonly IReadOnlyList<WrappedEvent> EmptyResult
 			= ImmutableList<WrappedEvent>.Empty;
 
@@ -25,18 +27,24 @@ namespace WalletWasabi.EventSourcing
 		private static readonly IComparer<WrappedEvent> WrappedEventSequenceIdComparer
 			= Comparer<WrappedEvent>.Create((a, b) => a.SequenceId.CompareTo(b.SequenceId));
 
-		private ConcurrentDictionary
+		private ConcurrentDictionary<
 			// aggregateType
-			<string,
-			ConcurrentDictionary
+			string,
+			ConcurrentDictionary<
 				// aggregateId
-				<string, AggregateEvents>> AggregatesEventsBatches
+				string,
+				AggregateEvents>> AggregatesEventsBatches
 		{ get; } = new();
 
-		private ConcurrentDictionary
+		private ConcurrentDictionary<
 			// aggregateType
-			<string,
+			string,
 			AggregateTypeIds> AggregatesIds
+		{ get; } = new();
+
+		private ConcurrentDictionary<
+			(string AggregateType, string AggregateId),
+			(long DeliveredSequenceId, long TailSequenceId)> UndeliveredSequenceIds
 		{ get; } = new();
 
 		/// <inheritdoc/>
@@ -50,28 +58,18 @@ namespace WalletWasabi.EventSourcing
 			Guard.NotNull(nameof(wrappedEvents), wrappedEvents);
 
 			var wrappedEventsList = wrappedEvents.ToList().AsReadOnly();
-
 			if (wrappedEventsList.Count == 0)
-			{
 				return Task.CompletedTask;
-			}
+
 			var firstSequenceId = wrappedEventsList[0].SequenceId;
 			var lastSequenceId = wrappedEventsList[^1].SequenceId;
 
 			if (firstSequenceId <= 0)
-			{
 				throw new ArgumentException("First event sequenceId is not natural number.", nameof(wrappedEvents));
-			}
-
 			if (lastSequenceId <= 0)
-			{
 				throw new ArgumentException("Last event sequenceId is not a positive integer.", nameof(wrappedEvents));
-			}
-
 			if (lastSequenceId - firstSequenceId + 1 != wrappedEventsList.Count)
-			{
 				throw new ArgumentException("Event sequence ids are inconsistent.", nameof(wrappedEvents));
-			}
 
 			var aggregateEventsBatches = AggregatesEventsBatches.GetOrAdd(aggregateType, _ => new());
 			var (tailSequenceId, events) = aggregateEventsBatches.GetOrAdd(
@@ -79,9 +77,7 @@ namespace WalletWasabi.EventSourcing
 				_ => new AggregateEvents(0, ImmutableList<WrappedEvent>.Empty));
 
 			if (tailSequenceId + 1 < firstSequenceId)
-			{
 				throw new ArgumentException($"Invalid firstSequenceId (gap in sequence ids) expected: '{tailSequenceId + 1}' given: '{firstSequenceId}'.", nameof(wrappedEvents));
-			}
 
 			// no action
 			Validated();
@@ -102,10 +98,10 @@ namespace WalletWasabi.EventSourcing
 
 			// If it is a first event for given aggregate.
 			if (tailSequenceId == 0)
-			{
 				// Add index of aggregate id into the dictionary.
 				IndexNewAggregateId(aggregateType, aggregateId);
-			}
+
+			MarkUndeliveredSequenceIds(aggregateType, aggregateId, tailSequenceId, lastSequenceId);
 			return Task.CompletedTask;
 		}
 
@@ -128,7 +124,6 @@ namespace WalletWasabi.EventSourcing
 					var dummyEvent = new WrappedEvent(afterSequenceId, null!, Guid.Empty);
 					var foundIndex = result.BinarySearch(dummyEvent, WrappedEventSequenceIdComparer);
 					if (foundIndex < 0)
-					{
 						// Note: this is because of BinarySearch() documented implementation
 						// returns "bitwise complement"
 						// see: https://docs.microsoft.com/en-us/dotnet/api/system.collections.immutable.immutablelist-1.binarysearch
@@ -137,22 +132,82 @@ namespace WalletWasabi.EventSourcing
 						// of the index of the next element that is larger than item or,
 						// if there is no larger element, the bitwise complement of Count.
 						foundIndex = ~foundIndex;
-					}
 					else
-					{
 						foundIndex++;
-					}
 					result = result.GetRange(foundIndex, result.Count - foundIndex);
 				}
-
 				if (maxCount < result.Count)
-				{
 					result = result.GetRange(0, maxCount.Value);
-				}
-
 				return Task.FromResult((IReadOnlyList<WrappedEvent>)result);
 			}
 			return Task.FromResult(EmptyResult);
+		}
+
+		/// <inheritdoc/>
+		public Task MarkEventsAsDeliveredCumulative(string aggregateType, string aggregateId, long deliveredSequenceId)
+		{
+			var liveLockLimit = LIVE_LOCK_LIMIT;
+			var conflict = false;
+			var prevDelieveredSequenceId = 0L;
+			var tailSequenceId = 0L;
+			do
+			{
+				conflict = false;
+				if (liveLockLimit-- <= 0)
+					throw new ApplicationException("Live lock detected.");
+				if (UndeliveredSequenceIds.TryGetValue((aggregateType, aggregateId), out var tuple))
+				{
+					// If sequenceId is already marked as delivered we are done.
+					if (deliveredSequenceId <= tuple.DeliveredSequenceId)
+						return Task.CompletedTask;
+					prevDelieveredSequenceId = tuple.DeliveredSequenceId;
+					tailSequenceId = tuple.TailSequenceId;
+
+#warning TODO:
+					// TODO: validate deliveredSequenceId
+
+					// If all events have been delivered
+					if (tailSequenceId == deliveredSequenceId)
+					{
+						conflict = !UndeliveredSequenceIds.TryRemove(((aggregateType, aggregateId), (prevDelieveredSequenceId, tailSequenceId)));
+					}
+					else
+					{
+						conflict = !UndeliveredSequenceIds.TryUpdate(
+							key: (aggregateType, aggregateId),
+							newValue: (deliveredSequenceId, tailSequenceId),
+							comparisonValue: (prevDelieveredSequenceId, tailSequenceId));
+					}
+				}
+				else
+				{
+#warning TODO:
+					// TODO:
+				}
+			} while (conflict);
+			return Task.CompletedTask;
+		}
+
+		/// <inheritdoc/>
+		public async Task<IReadOnlyList<AggregateUndeliveredEvents>> ListUndeliveredEventsAsync(int? maxCount = null)
+		{
+			if (maxCount < 1)
+				throw new ArgumentOutOfRangeException(nameof(maxCount), $"'{maxCount}' is not positive integer.");
+			var result = new List<AggregateUndeliveredEvents>();
+
+			foreach (
+				var ((aggregateType, aggregateId), (deliveredSequenceId, tailSequenceId))
+				in UndeliveredSequenceIds)
+			{
+				var events = await ListEventsAsync(aggregateType, aggregateId, deliveredSequenceId, maxCount)
+					.ConfigureAwait(false);
+				result.Add(new AggregateUndeliveredEvents(aggregateType, aggregateId, events));
+
+				maxCount -= events.Count;
+				if (maxCount <= 0)
+					break;
+			}
+			return result.AsReadOnly();
 		}
 
 		/// <inheritdoc/>
@@ -169,22 +224,16 @@ namespace WalletWasabi.EventSourcing
 				{
 					foundIndex = ids.IndexOf(afterAggregateId);
 					if (foundIndex < 0)
-					{
 						foundIndex = ~foundIndex;
-					}
 					else
-					{
 						foundIndex++;
-					}
 				}
 				List<string> result = new();
 				var afterLastIndex = maxCount.HasValue
 					? Math.Min(foundIndex + maxCount.Value, ids.Count)
 					: ids.Count;
 				for (var i = foundIndex; i < afterLastIndex; i++)
-				{
 					result.Add(ids[i]);
-				}
 				return Task.FromResult((IReadOnlyList<string>)result.AsReadOnly());
 			}
 			return Task.FromResult(EmptyIds);
@@ -195,21 +244,48 @@ namespace WalletWasabi.EventSourcing
 			var tailIndex = 0L;
 			ImmutableSortedSet<string> aggregateIds;
 			ImmutableSortedSet<string> newAggregateIds;
-			var liveLockLimit = 10000;
+			var liveLockLimit = LIVE_LOCK_LIMIT;
 			do
 			{
-				if (liveLockLimit <= 0)
-				{
+				if (liveLockLimit-- <= 0)
 					throw new ApplicationException("Live lock detected.");
-				}
-				liveLockLimit--;
 				(tailIndex, aggregateIds) = AggregatesIds.GetOrAdd(aggregateType, _ => new(0, ImmutableSortedSet<string>.Empty));
 				newAggregateIds = aggregateIds.Add(aggregateId);
+				if (newAggregateIds.Count == aggregateIds.Count)
+					throw new ApplicationException($"Aggregate id duplicate detected in '{nameof(InMemoryEventRepository)}.{nameof(IndexNewAggregateId)}'");
 			}
 			while (!AggregatesIds.TryUpdate(
 				key: aggregateType,
 				newValue: new AggregateTypeIds(tailIndex + 1, newAggregateIds),
 				comparisonValue: new AggregateTypeIds(tailIndex, aggregateIds)));
+		}
+
+		private void MarkUndeliveredSequenceIds(
+			string aggregateType,
+			string aggregateId,
+			long maxDeliveredSequenceId,
+			long tailSequenceId)
+		{
+			var liveLockLimit = LIVE_LOCK_LIMIT;
+			var deliveredSequenceId = 0L;
+			var prevTailSequenceId = 0L;
+			do
+			{
+				if (liveLockLimit-- <= 0)
+					throw new ApplicationException("Live lock detected.");
+				(deliveredSequenceId, prevTailSequenceId) =
+					UndeliveredSequenceIds.GetOrAdd(
+						key: (aggregateType, aggregateId),
+						value: (maxDeliveredSequenceId, tailSequenceId));
+
+				// If key was newly added to the dictionary we are done.
+				if (prevTailSequenceId == tailSequenceId)
+					return;
+			}
+			while (!UndeliveredSequenceIds.TryUpdate(
+					key: (aggregateType, aggregateId),
+					newValue: (deliveredSequenceId, tailSequenceId),
+					comparisonValue: (deliveredSequenceId, prevTailSequenceId)));
 		}
 
 		// Hook for parallel critical section testing in DEBUG build only.

--- a/WalletWasabi/EventSourcing/InMemoryEventRepository.cs
+++ b/WalletWasabi/EventSourcing/InMemoryEventRepository.cs
@@ -511,48 +511,6 @@ namespace WalletWasabi.EventSourcing
 			return Task.CompletedTask;
 		}
 
-		// Hook for parallel critical section testing.
-		protected virtual Task TryFixUndelivered_Entered()
-		{
-			// Keep empty. To be overriden in tests.
-			return Task.CompletedTask;
-		}
-
-		// Hook for parallel critical section testing.
-		protected virtual Task TryFixUndelivered_Detected()
-		{
-			// Keep empty. To be overriden in tests.
-			return Task.CompletedTask;
-		}
-
-		// Hook for parallel critical section testing.
-		protected virtual Task TryFixUndelivered_Removed()
-		{
-			// Keep empty. To be overriden in tests.
-			return Task.CompletedTask;
-		}
-
-		// Hook for parallel critical section testing.
-		protected virtual Task TryFixUndelivered_RemoveConflicted()
-		{
-			// Keep empty. To be overriden in tests.
-			return Task.CompletedTask;
-		}
-
-		// Hook for parallel critical section testing.
-		protected virtual Task TryFixUndelivered_Updated()
-		{
-			// Keep empty. To be overriden in tests.
-			return Task.CompletedTask;
-		}
-
-		// Hook for parallel critical section testing.
-		protected virtual Task TryFixUndelivered_UpdateConflicted()
-		{
-			// Keep empty. To be overriden in tests.
-			return Task.CompletedTask;
-		}
-
 		#endregion Hooks
 	}
 }

--- a/WalletWasabi/EventSourcing/Interfaces/IEventRepository.cs
+++ b/WalletWasabi/EventSourcing/Interfaces/IEventRepository.cs
@@ -62,8 +62,8 @@ namespace WalletWasabi.EventSourcing.Interfaces
 		/// by <see cref="AppendEventsAsync(string, string, IEnumerable{WrappedEvent})"/>
 		/// and not yet marked as delivered by <see cref="MarkEventsAsDeliveredCumulative(string, string, long)"/>.
 		/// </summary>
-		/// <returns>list of <see cref="UndeliveredEvent"/>s</returns>
-		public Task<IReadOnlyList<UndeliveredEvent>> ListUndeliveredEventsAsync(int? count);
+		/// <returns>list of <see cref="AggregateUndeliveredEvents"/></returns>
+		public Task<IReadOnlyList<AggregateUndeliveredEvents>> ListUndeliveredEventsAsync(int? maxCount = null);
 
 		/// <summary>
 		/// Supplementary method for enumerating all ids for <paramref name="aggregateType"/>

--- a/WalletWasabi/EventSourcing/Interfaces/IEventRepository.cs
+++ b/WalletWasabi/EventSourcing/Interfaces/IEventRepository.cs
@@ -12,11 +12,14 @@ namespace WalletWasabi.EventSourcing.Interfaces
 		/// In case of duplicate of <seealso cref="WrappedEvent.SequenceId"/>
 		/// <seealso cref="OptimisticConcurrencyException"/> is thrown indicating that
 		/// command should be retried with freshly loaded events from <see cref="ListEventsAsync"/>.
+		/// All appended events go into a list of undelivered events 👉 <see cref="ListUndeliveredEventsAsync(int?)"/>
 		/// </summary>
-		/// <param name="aggregateType">Type of aggregate</param>
-		/// <param name="aggregateId">Id of aggregate</param>
+		/// <param name="aggregateType">Type of an aggregate</param>
+		/// <param name="aggregateId">Id of an aggregate</param>
 		/// <param name="wrappedEvents">Ordered list of events to be persisted</param>
-		/// <exception cref="OptimisticConcurrencyException">If there is concurrency conflict ; retry command</exception>
+		/// <exception cref="OptimisticConcurrencyException">
+		/// If there is concurrency conflict ; retry command
+		/// </exception>
 		/// <exception cref="TransientException">Transient infrastructure failure</exception>
 		/// <exception cref="ArgumentException">Invalid input</exception>
 		public Task AppendEventsAsync(
@@ -28,8 +31,8 @@ namespace WalletWasabi.EventSourcing.Interfaces
 		/// List strongly ordered events of given aggregate. This is the primary source of truth.
 		/// Events are used to reconstruct aggregate state before processing command.
 		/// </summary>
-		/// <param name="aggregateType">Type of aggregate</param>
-		/// <param name="aggregateId">Id of aggregate</param>
+		/// <param name="aggregateType">Type of an aggregate</param>
+		/// <param name="aggregateId">Id of an aggregate</param>
 		/// <param name="afterSequenceId">Starts with event after given <seealso cref="WrappedEvent.SequenceId"/>
 		/// and lists all following events</param>
 		/// <param name="maxCount">Limits the number of returned events</param>
@@ -42,10 +45,31 @@ namespace WalletWasabi.EventSourcing.Interfaces
 			int? maxCount = null);
 
 		/// <summary>
+		/// Cumulatively marks events as delivered (e.g. to message bus) for given <paramref name="aggregateId"/>.
+		/// To be used in pair with <see cref="ListUndeliveredEventsAsync(int?)"/> method.
+		/// </summary>
+		/// <param name="aggregateType">Type of aggregate</param>
+		/// <param name="aggregateId">Id of aggregate</param>
+		/// <param name="deliveredSequenceId">sequenceId of last delivered event of the aggregate</param>
+		public Task MarkEventsAsDeliveredCumulative(
+			string aggregateType,
+			string aggregateId,
+			long deliveredSequenceId);
+
+		/// <summary>
+		/// Lists undelivered pending events to be delivered (e.g. to message bus) for all aggregates.
+		/// Event is considered undelivered if it has been appended
+		/// by <see cref="AppendEventsAsync(string, string, IEnumerable{WrappedEvent})"/>
+		/// and not yet marked as delivered by <see cref="MarkEventsAsDeliveredCumulative(string, string, long)"/>.
+		/// </summary>
+		/// <returns>list of <see cref="UndeliveredEvent"/>s</returns>
+		public Task<IReadOnlyList<UndeliveredEvent>> ListUndeliveredEventsAsync(int? count);
+
+		/// <summary>
 		/// Supplementary method for enumerating all ids for <paramref name="aggregateType"/>
 		/// in this event repository. Order of ids is not defined can be any artificial.
 		/// </summary>
-		/// <param name="aggregateType">Type of aggregate</param>
+		/// <param name="aggregateType">Type of an aggregate</param>
 		/// <param name="afterAggregateId">Starts with id right after given id and lists all following ids
 		/// in any artificial order</param>
 		/// <param name="maxCount">Limits the number of returned events</param>

--- a/WalletWasabi/EventSourcing/Interfaces/IEventRepository.cs
+++ b/WalletWasabi/EventSourcing/Interfaces/IEventRepository.cs
@@ -51,7 +51,7 @@ namespace WalletWasabi.EventSourcing.Interfaces
 		/// <param name="aggregateType">Type of aggregate</param>
 		/// <param name="aggregateId">Id of aggregate</param>
 		/// <param name="deliveredSequenceId">sequenceId of last delivered event of the aggregate</param>
-		public Task MarkEventsAsDeliveredCumulative(
+		public Task MarkEventsAsDeliveredCumulativeAsync(
 			string aggregateType,
 			string aggregateId,
 			long deliveredSequenceId);
@@ -60,7 +60,7 @@ namespace WalletWasabi.EventSourcing.Interfaces
 		/// Lists undelivered pending events to be delivered (e.g. to message bus) for all aggregates.
 		/// Event is considered undelivered if it has been appended
 		/// by <see cref="AppendEventsAsync(string, string, IEnumerable{WrappedEvent})"/>
-		/// and not yet marked as delivered by <see cref="MarkEventsAsDeliveredCumulative(string, string, long)"/>.
+		/// and not yet marked as delivered by <see cref="MarkEventsAsDeliveredCumulativeAsync(string, string, long)"/>.
 		/// </summary>
 		/// <returns>list of <see cref="AggregateUndeliveredEvents"/></returns>
 		public Task<IReadOnlyList<AggregateUndeliveredEvents>> ListUndeliveredEventsAsync(int? maxCount = null);

--- a/WalletWasabi/EventSourcing/Records/AggregateEvents.cs
+++ b/WalletWasabi/EventSourcing/Records/AggregateEvents.cs
@@ -2,16 +2,18 @@ using System.Collections.Immutable;
 
 namespace WalletWasabi.EventSourcing.Records
 {
-	public record AggregateEvents(long TailSequenceId, ImmutableList<WrappedEvent> Events)
-	{
-		/// <summary>
-		/// SequenceId of the last event of this aggregate
-		/// </summary>
-		public long TailSequenceId { get; init; } = TailSequenceId;
+    public record AggregateEvents(long TailSequenceId, ImmutableList<WrappedEvent> Events, Guid TransactionId)
+    {
+        /// <summary>
+        /// SequenceId of the last event of this aggregate
+        /// </summary>
+        public long TailSequenceId { get; init; } = TailSequenceId;
 
-		/// <summary>
-		/// Ordered list of events
-		/// </summary>
-		public ImmutableList<WrappedEvent> Events { get; init; } = Events;
-	}
+        /// <summary>
+        /// Ordered list of events
+        /// </summary>
+        public ImmutableList<WrappedEvent> Events { get; init; } = Events;
+
+        public Guid TransactionId { get; init; } = TransactionId;
+    }
 }

--- a/WalletWasabi/EventSourcing/Records/AggregateEvents.cs
+++ b/WalletWasabi/EventSourcing/Records/AggregateEvents.cs
@@ -2,18 +2,16 @@ using System.Collections.Immutable;
 
 namespace WalletWasabi.EventSourcing.Records
 {
-    public record AggregateEvents(long TailSequenceId, ImmutableList<WrappedEvent> Events, Guid TransactionId)
-    {
-        /// <summary>
-        /// SequenceId of the last event of this aggregate
-        /// </summary>
-        public long TailSequenceId { get; init; } = TailSequenceId;
+	public record AggregateEvents(long TailSequenceId, ImmutableList<WrappedEvent> Events)
+	{
+		/// <summary>
+		/// SequenceId of the last event of this aggregate
+		/// </summary>
+		public long TailSequenceId { get; init; } = TailSequenceId;
 
-        /// <summary>
-        /// Ordered list of events
-        /// </summary>
-        public ImmutableList<WrappedEvent> Events { get; init; } = Events;
-
-        public Guid TransactionId { get; init; } = TransactionId;
-    }
+		/// <summary>
+		/// Ordered list of events
+		/// </summary>
+		public ImmutableList<WrappedEvent> Events { get; init; } = Events;
+	}
 }

--- a/WalletWasabi/EventSourcing/Records/AggregateKey.cs
+++ b/WalletWasabi/EventSourcing/Records/AggregateKey.cs
@@ -1,0 +1,4 @@
+﻿namespace WalletWasabi.EventSourcing.Records
+{
+    public record AggregateKey(string AggregateType, string AggregateId);
+}

--- a/WalletWasabi/EventSourcing/Records/AggregateSequenceIds.cs
+++ b/WalletWasabi/EventSourcing/Records/AggregateSequenceIds.cs
@@ -1,0 +1,4 @@
+﻿namespace WalletWasabi.EventSourcing.Records
+{
+    public record AggregateSequenceIds(long DeliveredSequenceId, long TailSequenceId);
+}

--- a/WalletWasabi/EventSourcing/Records/AggregateSequenceIds.cs
+++ b/WalletWasabi/EventSourcing/Records/AggregateSequenceIds.cs
@@ -1,4 +1,4 @@
 ﻿namespace WalletWasabi.EventSourcing.Records
 {
-    public record AggregateSequenceIds(long DeliveredSequenceId, long TailSequenceId);
+    public record AggregateSequenceIds(long DeliveredSequenceId, long TailSequenceId, Guid TransactionId);
 }

--- a/WalletWasabi/EventSourcing/Records/AggregateSequenceIds.cs
+++ b/WalletWasabi/EventSourcing/Records/AggregateSequenceIds.cs
@@ -1,4 +1,4 @@
-﻿namespace WalletWasabi.EventSourcing.Records
+namespace WalletWasabi.EventSourcing.Records
 {
-    public record AggregateSequenceIds(long DeliveredSequenceId, long TailSequenceId, Guid TransactionId);
+	public record AggregateSequenceIds(long DeliveredSequenceId, long TransactionFirstSequenceId, long TransactionLastSequenceId);
 }

--- a/WalletWasabi/EventSourcing/Records/UndeliveredEvent.cs
+++ b/WalletWasabi/EventSourcing/Records/UndeliveredEvent.cs
@@ -1,4 +1,6 @@
+using System.Collections.Generic;
+
 namespace WalletWasabi.EventSourcing.Records
 {
-	public record UndeliveredEvent(string AggregateType, string AggregateId, WrappedEvent WrappedEvent);
+	public record AggregateUndeliveredEvents(string AggregateType, string AggregateId, IReadOnlyList<WrappedEvent> WrappedEvents);
 }

--- a/WalletWasabi/EventSourcing/Records/UndeliveredEvent.cs
+++ b/WalletWasabi/EventSourcing/Records/UndeliveredEvent.cs
@@ -2,5 +2,6 @@ using System.Collections.Generic;
 
 namespace WalletWasabi.EventSourcing.Records
 {
-	public record AggregateUndeliveredEvents(string AggregateType, string AggregateId, IReadOnlyList<WrappedEvent> WrappedEvents);
+	public record AggregateUndeliveredEvents(string AggregateType, string AggregateId, IReadOnlyList<WrappedEvent> WrappedEvents)
+		: AggregateKey(AggregateType, AggregateId);
 }

--- a/WalletWasabi/EventSourcing/Records/UndeliveredEvent.cs
+++ b/WalletWasabi/EventSourcing/Records/UndeliveredEvent.cs
@@ -1,0 +1,4 @@
+namespace WalletWasabi.EventSourcing.Records
+{
+	public record UndeliveredEvent(string AggregateType, string AggregateId, WrappedEvent WrappedEvent);
+}


### PR DESCRIPTION
Closes #10 

Because of the unsolvable Two Generals' Problem we need two phase event delivery to PubSub after the event is appended to EventStore to guarantee at-least-once event delivery to PubSub.

We added two methods to IEventRepository
* ListUndeliveredEventsAsync()
    * lists events for all agregates that has been appended and not yet marked as delivered
    * it is guaranteed to return all successfully appended events even in case of any kind of failure. Either event has been appended and it is returned by both this method and ListEventsAsync() or it has not been appended and then it is not returned by neither.
* MarkEventsAsDeliveredCumulativeAsync(
			string aggregateType,
			string aggregateId,
			long deliveredSequenceId)
    * marks events of given aggregate as delivered to no longer be returned by ListUndeliveredEventsAsync().

Combination of these two methods allows at-least-once delivery guarantee. We will deliver events repeatedly until they are all marked as delivered. e.g. redeliver all undelivered events on startup. 

21 hours spent on this task 😅 It has been more difficult than expected for two methods. But making thread safe code is difficult.