### PR TITLE
Add SpendableCoin variations

### DIFF
--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepTransactionSigningTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/PhaseStepping/StepTransactionSigningTests.cs
@@ -164,7 +164,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PhaseStepping
 			Assert.Equal(Phase.Ended, round.Phase);
 			Assert.False(round.WasTransactionBroadcast);
 			Assert.Empty(arena.Rounds.Where(x => x is BlameRound));
-			Assert.Contains(aliceClient2.SmartCoin.OutPoint, prison.GetInmates().Select(x => x.Utxo));
+			Assert.Contains(aliceClient2.SpendableCoin.OutPoint, prison.GetInmates().Select(x => x.Utxo));
 
 			await arena.StopAsync(CancellationToken.None);
 		}
@@ -213,8 +213,8 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Backend.PhaseStepping
 			Assert.Equal(round.Id, blameRound.BlameOf.Id);
 
 			var whitelist = blameRound.BlameWhitelist;
-			Assert.Contains(aliceClient1.SmartCoin.OutPoint, whitelist);
-			Assert.Contains(aliceClient2.SmartCoin.OutPoint, whitelist);
+			Assert.Contains(aliceClient1.SpendableCoin.OutPoint, whitelist);
+			Assert.Contains(aliceClient2.SpendableCoin.OutPoint, whitelist);
 			Assert.DoesNotContain(badOutpoint, whitelist);
 
 			await arena.StopAsync(CancellationToken.None);

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Client/ArenaClientTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Client/ArenaClientTests.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.Caching.Memory;
 using Moq;
 using NBitcoin;
 using NBitcoin.RPC;
+using System;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/Participant.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Integration/Participant.cs
@@ -90,7 +90,7 @@ namespace WalletWasabi.Tests.UnitTests.WabiSabi.Integration
 			var spendableCoins = Coins.Select(c => SpendableSmartCoin.Create(c, KeyManager));
 
 			// Run the coinjoin client task.
-			await coinJoinClient.StartCoinJoinAsync(spendableCoins, KeyManager.GetSelfSpendDestinations, cancellationToken).ConfigureAwait(false);
+			await coinJoinClient.StartCoinJoinAsync(spendableCoins, KeyManager.GetSelfSpendScripts, cancellationToken).ConfigureAwait(false);
 
 			await roundStateUpdater.StopAsync(cancellationToken).ConfigureAwait(false);
 		}

--- a/WalletWasabi/Blockchain/Keys/KeyManager.cs
+++ b/WalletWasabi/Blockchain/Keys/KeyManager.cs
@@ -380,10 +380,10 @@ namespace WalletWasabi.Blockchain.Keys
 			ToFile();
 		}
 
-		public IEnumerable<IDestination> GetSelfSpendDestinations(int howMany)
+		public IEnumerable<Script> GetSelfSpendScripts(int howMany)
 		{
 			AssertLockedInternalKeysIndexed(howMany);
-			return GetKeys(x => x.IsInternal && x.KeyState == KeyState.Locked).Cast<IDestination>();
+			return GetKeys(x => x.IsInternal && x.KeyState == KeyState.Locked).Select(x => x.P2wpkhScript);
 		}
 
 		public IEnumerable<HdPubKey> GetKeys(KeyState? keyState = null, bool? isInternal = null)

--- a/WalletWasabi/Blockchain/Keys/KeyManager.cs
+++ b/WalletWasabi/Blockchain/Keys/KeyManager.cs
@@ -380,6 +380,12 @@ namespace WalletWasabi.Blockchain.Keys
 			ToFile();
 		}
 
+		public IEnumerable<IDestination> GetSelfSpendDestinations(int howMany)
+		{
+			AssertLockedInternalKeysIndexed(howMany);
+			return GetKeys(x => x.IsInternal && x.KeyState == KeyState.Locked).Cast<IDestination>();
+		}
+
 		public IEnumerable<HdPubKey> GetKeys(KeyState? keyState = null, bool? isInternal = null)
 		{
 			if (keyState is null)

--- a/WalletWasabi/Blockchain/TransactionOutputs/IMutableCoinJoinProperties.cs
+++ b/WalletWasabi/Blockchain/TransactionOutputs/IMutableCoinJoinProperties.cs
@@ -1,0 +1,11 @@
+namespace WalletWasabi.Blockchain.TransactionOutputs
+{
+	public interface IMutableCoinJoinProperties
+	{
+		bool CoinJoinInProgress { get; set; }
+		bool SpentAccordingToBackend { get; set; }
+		DateTimeOffset? BannedUntilUtc { get; set; }
+
+		void SetIsBanned();
+	}
+}

--- a/WalletWasabi/Extensions/NBitcoinExtensions.cs
+++ b/WalletWasabi/Extensions/NBitcoinExtensions.cs
@@ -7,7 +7,6 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using WalletWasabi.Blockchain.Keys;
-using WalletWasabi.Blockchain.TransactionOutputs;
 using WalletWasabi.Blockchain.Transactions;
 using WalletWasabi.Helpers;
 using WalletWasabi.Logging;
@@ -468,9 +467,6 @@ namespace NBitcoin
 
 		public static Money EffectiveValue(this Coin coin, FeeRate feeRate) =>
 			coin.Amount - feeRate.GetFee(coin.ScriptPubKey.EstimateInputVsize());
-
-		public static Money EffectiveValue(this SmartCoin coin, FeeRate feeRate) =>
-			EffectiveValue(coin.Coin, feeRate);
 
 		public static T FromBytes<T>(byte[] input) where T : IBitcoinSerializable, new()
 		{

--- a/WalletWasabi/WabiSabi/Client/AmountDecomposer.cs
+++ b/WalletWasabi/WabiSabi/Client/AmountDecomposer.cs
@@ -1,7 +1,7 @@
+using NBitcoin;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
-using NBitcoin;
 using WalletWasabi.WabiSabi.Models.Decomposition;
 
 namespace WalletWasabi.WabiSabi.Client
@@ -27,7 +27,7 @@ namespace WalletWasabi.WabiSabi.Client
 		public int OutputSize { get; }
 		private ImmutableArray<Money> StandardDenominationsPlusFee { get; }
 
-		public IEnumerable<Money> Decompose(IEnumerable<Coin> myInputCoins, IEnumerable<Coin> allInputCoins)
+		public IEnumerable<Money> Decompose(IEnumerable<IAbstractCoin> myInputCoins, IEnumerable<IAbstractCoin> allInputCoins)
 		{
 			var histogram = GetDenominationFrequency(allInputCoins);
 
@@ -73,7 +73,7 @@ namespace WalletWasabi.WabiSabi.Client
 			return outputAmounts;
 		}
 
-		private Dictionary<Money, long> GetDenominationFrequency(IEnumerable<Coin> allInputCoins)
+		private Dictionary<Money, long> GetDenominationFrequency(IEnumerable<IAbstractCoin> allInputCoins)
 		{
 			var secondLargestInput = allInputCoins.OrderByDescending(x => x.Amount).Skip(1).FirstOrDefault();
 			IEnumerable<Money> demonsForBreakDown = StandardDenominationsPlusFee.Where(x => secondLargestInput is null || x <= secondLargestInput.EffectiveValue(FeeRate));
@@ -94,7 +94,7 @@ namespace WalletWasabi.WabiSabi.Client
 			return denomProbabilities;
 		}
 
-		private IEnumerable<Money> BreakDown(Coin coin, IEnumerable<Money> denominations)
+		private IEnumerable<Money> BreakDown(IAbstractCoin coin, IEnumerable<Money> denominations)
 		{
 			var remaining = coin.EffectiveValue(FeeRate);
 

--- a/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinClient.cs
@@ -103,7 +103,7 @@ namespace WalletWasabi.WabiSabi.Client
 				InCriticalCoinJoinState = true;
 
 				// Calculate outputs values
-				var registeredCoins = registeredAliceClients.Select(x => x.SmartCoin.Coin);
+				var registeredCoins = registeredAliceClients.Select(x => x.SpendableCoin.SmartCoin.Coin);
 				var availableVsize = registeredAliceClients.SelectMany(x => x.IssuedVsizeCredentials).Sum(x => x.Value);
 
 				// Calculate outputs values
@@ -203,7 +203,7 @@ namespace WalletWasabi.WabiSabi.Client
 			}
 
 			// Gets the list of scheduled dates/time in the remaining available time frame when each alice has to be registered.
-			var remainingTimeForRegistration = ( roundState.InputRegistrationEnd - DateTimeOffset.UtcNow ) - TimeSpan.FromSeconds(15);
+			var remainingTimeForRegistration = (roundState.InputRegistrationEnd - DateTimeOffset.UtcNow) - TimeSpan.FromSeconds(15);
 
 			Logger.LogDebug($"Round ({roundState.Id}): Input registration started, it will end in {remainingTimeForRegistration.TotalMinutes} minutes.");
 

--- a/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoinManager.cs
@@ -78,7 +78,7 @@ namespace WalletWasabi.WabiSabi.Client
 
 					var coinjoinClient = new CoinJoinClient(HttpClientFactory, RoundStatusUpdater);
 					var cts = CancellationTokenSource.CreateLinkedTokenSource(stoppingToken);
-					var coinjoinTask = coinjoinClient.StartCoinJoinAsync(coinCandidates, openedWallet.KeyManager.GetSelfSpendDestinations, cts.Token);
+					var coinjoinTask = coinjoinClient.StartCoinJoinAsync(coinCandidates, openedWallet.KeyManager.GetSelfSpendScripts, cts.Token);
 
 					trackedWallets.Add(openedWallet.WalletName, new WalletTrackingData(openedWallet, coinjoinClient, coinjoinTask, coinCandidates.Select(x => x.SmartCoin), cts));
 					WalletStatusChanged?.Invoke(this, new WalletStatusChangedEventArgs(openedWallet, IsCoinJoining: true));

--- a/WalletWasabi/WabiSabi/Client/CredentialDependencies/DependencyGraph.cs
+++ b/WalletWasabi/WabiSabi/Client/CredentialDependencies/DependencyGraph.cs
@@ -49,7 +49,7 @@ namespace WalletWasabi.WabiSabi.Client.CredentialDependencies
 		/// and may contain additional nodes if reissuance requests are
 		/// required.</remarks>
 		///
-		public static DependencyGraph ResolveCredentialDependencies(IEnumerable<Coin> inputs, IEnumerable<TxOut> outputs, FeeRate feerate, long vsizeAllocationPerInput)
+		public static DependencyGraph ResolveCredentialDependencies(IEnumerable<IAbstractCoin> inputs, IEnumerable<TxOut> outputs, FeeRate feerate, long vsizeAllocationPerInput)
 		{
 			var inputSizes = inputs.Select(x => x.ScriptPubKey.EstimateInputVsize());
 			var effectiveValues = Enumerable.Zip(inputs, inputSizes, (coin, size) => coin.EffectiveValue(feerate));

--- a/WalletWasabi/WabiSabi/Client/IAbstractCoin.cs
+++ b/WalletWasabi/WabiSabi/Client/IAbstractCoin.cs
@@ -1,0 +1,24 @@
+using NBitcoin;
+
+namespace WalletWasabi.WabiSabi.Client
+{
+	// NBitcoin's ICoin is for abstracting colored coin functionality, this
+	// ICoin is only for BTC, and added for polymorphism reasons.
+	public interface IAbstractCoin
+	{
+		TxOut TxOut { get; }
+		OutPoint Outpoint { get; } // TODO deprecate?
+		OutPoint OutPoint => Outpoint;
+
+		Script ScriptPubKey => TxOut.ScriptPubKey;
+		Money Amount => TxOut.Value;
+
+		Money EffectiveValue(FeeRate feeRate) => Amount - feeRate.GetFee(ScriptPubKey.EstimateInputVsize());
+	}
+
+	public record CoinAdaptor(Coin Coin) : IAbstractCoin
+	{
+		public TxOut TxOut => Coin.TxOut;
+		public OutPoint Outpoint => Coin.Outpoint;
+	}
+}

--- a/WalletWasabi/WabiSabi/Client/IAbstractCoinWithOwnershipProvingCapability.cs
+++ b/WalletWasabi/WabiSabi/Client/IAbstractCoinWithOwnershipProvingCapability.cs
@@ -1,0 +1,9 @@
+using WalletWasabi.Crypto;
+
+namespace WalletWasabi.WabiSabi.Client
+{
+	public interface IAbstractCoinWithOwnershipProvingCapability : IAbstractCoin
+	{
+		OwnershipProof GenerateOwnershipProof(CoinJoinInputCommitmentData commitmentData);
+	}
+}

--- a/WalletWasabi/WabiSabi/Client/IAbstractCoinWithSignCapability.cs
+++ b/WalletWasabi/WabiSabi/Client/IAbstractCoinWithSignCapability.cs
@@ -1,0 +1,9 @@
+using NBitcoin;
+
+namespace WalletWasabi.WabiSabi.Client
+{
+	public interface IAbstractCoinWithSignCapability : IAbstractCoin
+	{
+		void Sign(Transaction transaction);
+	}
+}

--- a/WalletWasabi/WabiSabi/Client/ISpendableCoin.cs
+++ b/WalletWasabi/WabiSabi/Client/ISpendableCoin.cs
@@ -1,0 +1,6 @@
+namespace WalletWasabi.WabiSabi.Client
+{
+	public interface ISpendableCoin : IAbstractCoinWithSignCapability, IAbstractCoinWithOwnershipProvingCapability
+	{
+	}
+}

--- a/WalletWasabi/WabiSabi/Client/ISpendableSmartCoin.cs
+++ b/WalletWasabi/WabiSabi/Client/ISpendableSmartCoin.cs
@@ -1,0 +1,10 @@
+using WalletWasabi.Blockchain.Keys;
+using WalletWasabi.Blockchain.TransactionOutputs;
+
+namespace WalletWasabi.WabiSabi.Client
+{
+	public interface ISpendableSmartCoin : ISpendableCoin, IMutableCoinJoinProperties
+	{
+		public HdPubKey HdPubKey { get; }
+	}
+}

--- a/WalletWasabi/WabiSabi/Client/SpendableCoin.cs
+++ b/WalletWasabi/WabiSabi/Client/SpendableCoin.cs
@@ -2,10 +2,11 @@ using NBitcoin;
 
 namespace WalletWasabi.WabiSabi.Client
 {
-	public record SpendableCoin(Coin Coin, BitcoinSecret BitcoinSecret)
+	public record SpendableCoin(Coin Coin, BitcoinSecret BitcoinSecret) : IAbstractCoinWithSignCapability
 	{
 		// TODO provide minimal interfaces
 		public Money Amount => Coin.Amount;
+		public TxOut TxOut => Coin.TxOut;
 		public Script ScriptPubKey => Coin.ScriptPubKey;
 		public OutPoint OutPoint => Coin.Outpoint;
 

--- a/WalletWasabi/WabiSabi/Client/SpendableCoin.cs
+++ b/WalletWasabi/WabiSabi/Client/SpendableCoin.cs
@@ -1,0 +1,20 @@
+using NBitcoin;
+
+namespace WalletWasabi.WabiSabi.Client
+{
+	public record SpendableCoin(Coin Coin, BitcoinSecret BitcoinSecret)
+	{
+		// TODO provide minimal interfaces
+		public Money Amount => Coin.Amount;
+		public Script ScriptPubKey => Coin.ScriptPubKey;
+		public OutPoint OutPoint => Coin.Outpoint;
+
+		[Obsolete("not sure which one to deprecate to be honest, but OutPoint vs Outpoint is inconsistent. follow Core?")]
+		public OutPoint Outpoint => Coin.Outpoint;
+
+		public void Sign(Transaction transaction)
+		{
+			transaction.Sign(BitcoinSecret, Coin);
+		}
+	}
+}

--- a/WalletWasabi/WabiSabi/Client/SpendableSmartCoin.cs
+++ b/WalletWasabi/WabiSabi/Client/SpendableSmartCoin.cs
@@ -1,0 +1,35 @@
+using NBitcoin;
+using WalletWasabi.Blockchain.TransactionOutputs;
+using WalletWasabi.Crypto;
+
+namespace WalletWasabi.WabiSabi.Client
+{
+	// There's no interface shared by Coin and SmartCoin, so as a temporary fix
+	// just have two separate variants that don't both inhabit a polymorphic
+	// type, because CJC needs smartcoin functionality, but ArenaClient tests
+	// use Coin not SmartCoin, but unification is the goal of this refactor. An
+	// implicit conversion is provided as a syntactic bridge.
+	public record SpendableSmartCoin(SmartCoin SmartCoin, BitcoinSecret BitcoinSecret, Key IdentificationKey)
+	{
+		public OwnershipProof GenerateOwnershipProof(CoinJoinInputCommitmentData commitmentData)
+		=> OwnershipProof.GenerateCoinJoinInputProof(
+					BitcoinSecret.PrivateKey,
+					new OwnershipIdentifier(IdentificationKey, BitcoinSecret.PrivateKey.PubKey.WitHash.ScriptPubKey),
+					commitmentData);
+
+		// TODO provide minimal interfaces
+		public Money Amount => SmartCoin.Amount;
+		public Script ScriptPubKey => SmartCoin.ScriptPubKey;
+		public OutPoint OutPoint => SmartCoin.Coin.Outpoint;
+
+		[Obsolete("not sure which one to deprecate to be honest, but OutPoint vs Outpoint is inconsistent. follow Core?")]
+		public OutPoint Outpoint => SmartCoin.Coin.Outpoint;
+
+		public void Sign(Transaction transaction)
+		{
+			transaction.Sign(BitcoinSecret, SmartCoin.Coin);
+		}
+
+		public static implicit operator SpendableCoin(SpendableSmartCoin coin) => new(coin.SmartCoin.Coin, coin.BitcoinSecret);
+	}
+}

--- a/WalletWasabi/WabiSabi/Client/SpendableSmartCoin.cs
+++ b/WalletWasabi/WabiSabi/Client/SpendableSmartCoin.cs
@@ -12,7 +12,7 @@ namespace WalletWasabi.WabiSabi.Client
 	// type, because CJC needs smartcoin functionality, but ArenaClient tests
 	// use Coin not SmartCoin, but unification is the goal of this refactor. An
 	// implicit conversion is provided as a syntactic bridge.
-	public record SpendableSmartCoin(SmartCoin SmartCoin, BitcoinSecret BitcoinSecret, Key IdentificationKey)
+	public record SpendableSmartCoin(SmartCoin SmartCoin, BitcoinSecret BitcoinSecret, Key IdentificationKey) : ISpendableSmartCoin
 	{
 		public OwnershipProof GenerateOwnershipProof(CoinJoinInputCommitmentData commitmentData)
 		=> OwnershipProof.GenerateCoinJoinInputProof(
@@ -22,15 +22,12 @@ namespace WalletWasabi.WabiSabi.Client
 
 		// TODO provide minimal interfaces
 		public TxOut TxOut => SmartCoin.TxOut;
-		public uint Index => SmartCoin.Index;
-		public Money Amount => SmartCoin.Amount;
-		public uint256 TransactionId => SmartCoin.TransactionId;
-		public Script ScriptPubKey => SmartCoin.ScriptPubKey;
-		public HdPubKey HdPubKey => SmartCoin.HdPubKey;
-		public OutPoint OutPoint => SmartCoin.Coin.Outpoint;
-
-		[Obsolete("not sure which one to deprecate to be honest, but OutPoint vs Outpoint is inconsistent. follow Core?")]
 		public OutPoint Outpoint => SmartCoin.Coin.Outpoint;
+		public HdPubKey HdPubKey => SmartCoin.HdPubKey;
+
+		public bool CoinJoinInProgress { get => SmartCoin.CoinJoinInProgress; set => SmartCoin.CoinJoinInProgress = value; }
+		public bool SpentAccordingToBackend { get => SmartCoin.SpentAccordingToBackend; set => SmartCoin.SpentAccordingToBackend = value; }
+		public DateTimeOffset? BannedUntilUtc { get => SmartCoin.BannedUntilUtc; set => SmartCoin.BannedUntilUtc = value; }
 
 		public void Sign(Transaction transaction)
 		{
@@ -64,6 +61,11 @@ namespace WalletWasabi.WabiSabi.Client
 			var identificationKey = identificationMasterKey.DeriveChild("SLIP-0019").DeriveChild("Ownership identification key").Key;
 
 			return new SpendableSmartCoin(coin, secret, identificationKey);
+		}
+
+		public void SetIsBanned()
+		{
+			SmartCoin.SetIsBanned();
 		}
 	}
 }

--- a/WalletWasabi/WabiSabi/Models/MoneyRange.cs
+++ b/WalletWasabi/WabiSabi/Models/MoneyRange.cs
@@ -5,6 +5,8 @@ namespace WalletWasabi.WabiSabi.Models
 	public record MoneyRange(Money Min, Money Max)
 	{
 		public bool Contains(Money value) =>
-			value >= Min && value <= Max;
+			Min <= value && value <= Max;
+		public bool Contains(IMoney value) =>
+			Min.CompareTo(value) <= 0 && value.CompareTo(Max) <= 0;
 	}
 }


### PR DESCRIPTION
Some loose ends still, but CJC and everything below it no longer depend on `KeyManager` and `Kitchen` directly, instead interacting with them through two concrete types (`SpendableSmartCoin` and `SpendableCoin`) which implement a narrower family of interfaces (`IAbstractCoin` which is based on `NBitcoin.Coin` but narrower than `NBitcoin.ICoin`, and interfaces for the sign & ownership proof capabilities, and `SmartCoin` based metadata like the coinjoin status).