### PR TITLE
Build & run tests with coverage in GH actions

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -40,8 +40,8 @@ jobs:
       run: dotnet test --no-restore --filter "(FullyQualifiedName~UnitTests)&(FullyQualifiedName!~WabiSabi)" --logger "console;verbosity=detailed"
 
     - name: Build (Release)
-      run: dotnet build --configuration Release --no-restore
-    
+      run: dotnet build --configuration Release --no-restore /p:ContinuousIntegrationBuild=true
+
     - name: '"Integration" "Unit" Tests'
       run: dotnet test --configuration Release --no-restore --filter "(FullyQualifiedName~UnitTests)&(FullyQualifiedName~Integration)" --logger "console;verbosity=detailed"
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -31,7 +31,19 @@ jobs:
       run: dotnet restore
       
     - name: Build
+      run: dotnet build --no-restore
+
+    - name: WabiSabi "Unit" Tests
+      run: dotnet test --no-restore --filter "(FullyQualifiedName!~Integration)&(FullyQualifiedName~WabiSabi)" --logger "console;verbosity=detailed"
+
+    - name: Other "Unit" Tests
+      run: dotnet test --no-restore --filter "(FullyQualifiedName~UnitTests)&(FullyQualifiedName!~WabiSabi)" --logger "console;verbosity=detailed"
+
+    - name: Build (Release)
       run: dotnet build --configuration Release --no-restore
     
-    - name: Test
-      run: dotnet test --no-restore --filter "UnitTests" --logger "console;verbosity=detailed"
+    - name: '"Integration" "Unit" Tests'
+      run: dotnet test --configuration Release --no-restore --filter "(FullyQualifiedName~UnitTests)&(FullyQualifiedName~Integration)" --logger "console;verbosity=detailed"
+
+    - name: '"Integration" Tests'
+      run: dotnet test --configuration Release --no-restore --filter "(FullyQualifiedName!~UnitTests)" --logger "console;verbosity=detailed"

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -27,23 +27,32 @@ jobs:
       with:
         dotnet-version: ${{ env.DOTNET_VERSION }}
 
-    - name: Install dependencies
+    - name: Restore
       run: dotnet restore
-      
+
     - name: Build
       run: dotnet build --no-restore
 
     - name: WabiSabi "Unit" Tests
-      run: dotnet test --no-restore --filter "(FullyQualifiedName!~Integration)&(FullyQualifiedName~WabiSabi)" --logger "console;verbosity=detailed"
+      run: dotnet test --no-build --filter "(FullyQualifiedName!~Integration)&(FullyQualifiedName~WabiSabi)" --logger "console;verbosity=detailed" --collect:"XPlat Code Coverage" --logger trx
 
     - name: Other "Unit" Tests
-      run: dotnet test --no-restore --filter "(FullyQualifiedName~UnitTests)&(FullyQualifiedName!~WabiSabi)" --logger "console;verbosity=detailed"
+      run: dotnet test --no-build --filter "(FullyQualifiedName~UnitTests)&(FullyQualifiedName!~WabiSabi)" --logger "console;verbosity=detailed" --collect:"XPlat Code Coverage" --logger trx 
 
     - name: Build (Release)
       run: dotnet build --configuration Release --no-restore /p:ContinuousIntegrationBuild=true
 
     - name: '"Integration" "Unit" Tests'
-      run: dotnet test --configuration Release --no-restore --filter "(FullyQualifiedName~UnitTests)&(FullyQualifiedName~Integration)" --logger "console;verbosity=detailed"
+      run: dotnet test --configuration Release --no-build --filter "(FullyQualifiedName~UnitTests)&(FullyQualifiedName~Integration)" --logger "console;verbosity=detailed" --collect:"XPlat Code Coverage" --logger trx 
 
-    - name: '"Integration" Tests'
-      run: dotnet test --configuration Release --no-restore --filter "(FullyQualifiedName!~UnitTests)" --logger "console;verbosity=detailed"
+    #- name: '"Integration" Tests'
+    #  run: dotnet test --configuration Release --no-build --filter "(FullyQualifiedName!~UnitTests)" --logger "console;verbosity=detailed" --collect:"XPlat Code Coverage" --logger trx
+
+    - uses: actions/upload-artifact@v2
+      with:
+        name: TestResults
+        path: WalletWasabi.Tests/TestResults
+
+    - uses: codecov/codecov-action@v2
+      with:
+        fail_ci_if_error: true

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -12,9 +12,9 @@ env:
   DOTNET_VERSION: '6.0.101'
 
 jobs:
-  build-and-test:
+  test:
 
-    name: build-and-test-${{matrix.os}}
+    name: test-${{matrix.os}}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -39,14 +39,11 @@ jobs:
     - name: Other "Unit" Tests
       run: dotnet test --no-build --filter "(FullyQualifiedName~UnitTests)&(FullyQualifiedName!~WabiSabi)" --logger "console;verbosity=detailed" --collect:"XPlat Code Coverage" --logger trx 
 
-    - name: Build (Release)
-      run: dotnet build --configuration Release --no-restore /p:ContinuousIntegrationBuild=true
-
     - name: '"Integration" "Unit" Tests'
-      run: dotnet test --configuration Release --no-build --filter "(FullyQualifiedName~UnitTests)&(FullyQualifiedName~Integration)" --logger "console;verbosity=detailed" --collect:"XPlat Code Coverage" --logger trx 
+      run: dotnet test --no-build --filter "(FullyQualifiedName~UnitTests)&(FullyQualifiedName~Integration)" --logger "console;verbosity=detailed" --collect:"XPlat Code Coverage" --logger trx 
 
     #- name: '"Integration" Tests'
-    #  run: dotnet test --configuration Release --no-build --filter "(FullyQualifiedName!~UnitTests)" --logger "console;verbosity=detailed" --collect:"XPlat Code Coverage" --logger trx
+    #  run: dotnet test --no-build --filter "(FullyQualifiedName!~UnitTests)" --logger "console;verbosity=detailed" --collect:"XPlat Code Coverage" --logger trx
 
     - uses: actions/upload-artifact@v2
       with:
@@ -56,3 +53,56 @@ jobs:
     - uses: codecov/codecov-action@v2
       with:
         fail_ci_if_error: true
+
+  build-backend:
+    name: build-backend-${{matrix.os}}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup .NET Core
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: ${{ env.DOTNET_VERSION }}
+
+    - name: Restore
+      run: dotnet restore
+
+    - name: Publish
+      run: dotnet publish --configuration Release --self-contained false /p:ContinuousIntegrationBuild=true WalletWasabi.Backend
+
+    - uses: actions/upload-artifact@v2
+      with:
+        name: Backend (built on ${{matrix.os}})
+        path: "WalletWasabi.Backend/bin/Release/*/publish"
+
+  build-gui-with-packager:
+    name: build-gui-${{matrix.os}}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup .NET Core
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: ${{ env.DOTNET_VERSION }}
+
+    - name: Restore
+      run: dotnet restore
+
+    - name: Build Packager
+      run: dotnet build --no-restore WalletWasabi.Packager
+
+    - name: Packager
+      run: cd WalletWasabi.Packager; dotnet run -- --onlybinaries
+
+    - uses: actions/upload-artifact@v2
+      with:
+        name: Packager outputs (built on ${{matrix.os}})
+        path: "*/bin/dist"

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,0 +1,37 @@
+name: build and test
+
+on:
+  push:
+  pull_request:
+    branches: [ master ]
+    paths:
+    - '**.cs'
+    - '**.csproj'
+
+env:
+  DOTNET_VERSION: '6.0.101'
+
+jobs:
+  build-and-test:
+
+    name: build-and-test-${{matrix.os}}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup .NET Core
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: ${{ env.DOTNET_VERSION }}
+
+    - name: Install dependencies
+      run: dotnet restore
+      
+    - name: Build
+      run: dotnet build --configuration Release --no-restore
+    
+    - name: Test
+      run: dotnet test --no-restore --filter "UnitTests" --logger "console;verbosity=detailed"

--- a/WalletWasabi.Backend/WalletWasabi.Backend.csproj
+++ b/WalletWasabi.Backend/WalletWasabi.Backend.csproj
@@ -15,7 +15,6 @@
 		<Nullable>enable</Nullable>
 		<InvariantGlobalization>true</InvariantGlobalization>
 		<RuntimeIdentifiers>win7-x64;linux-x64;osx-x64</RuntimeIdentifiers>
-		<PathMap>$(MSBuildProjectDirectory)\=WalletWasabi.Backend</PathMap>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/WalletWasabi.Fluent.Desktop/WalletWasabi.Fluent.Desktop.csproj
+++ b/WalletWasabi.Fluent.Desktop/WalletWasabi.Fluent.Desktop.csproj
@@ -19,7 +19,6 @@
 		<DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
 		<InvariantGlobalization>true</InvariantGlobalization>
 		<RuntimeIdentifiers>win7-x64;linux-x64;osx-x64</RuntimeIdentifiers>
-		<PathMap>$(MSBuildProjectDirectory)\=WalletWasabi.Fluent.Desktop</PathMap>
 	</PropertyGroup>
 
 	<PropertyGroup>

--- a/WalletWasabi.Fluent.Generators/WalletWasabi.Fluent.Generators.csproj
+++ b/WalletWasabi.Fluent.Generators/WalletWasabi.Fluent.Generators.csproj
@@ -11,7 +11,6 @@
 		<DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
 		<InvariantGlobalization>true</InvariantGlobalization>
 		<RuntimeIdentifiers>win7-x64;linux-x64;osx-x64</RuntimeIdentifiers>
-		<PathMap>$(MSBuildProjectDirectory)\=WalletWasabi.Fluent.Generators</PathMap>
 		<IsRoslynComponent>true</IsRoslynComponent>
     </PropertyGroup>
 

--- a/WalletWasabi.Fluent/WalletWasabi.Fluent.csproj
+++ b/WalletWasabi.Fluent/WalletWasabi.Fluent.csproj
@@ -12,7 +12,6 @@
 		<DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
 		<InvariantGlobalization>true</InvariantGlobalization>
 		<RuntimeIdentifiers>win7-x64;linux-x64;osx-x64</RuntimeIdentifiers>
-		<PathMap>$(MSBuildProjectDirectory)\=WalletWasabi.Fluent</PathMap>
 		<AvaloniaVersion>0.10.11-rc.2</AvaloniaVersion>
 	</PropertyGroup>
 	<ItemGroup>

--- a/WalletWasabi.Packager/Program.cs
+++ b/WalletWasabi.Packager/Program.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.Json;
-using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using WalletWasabi.Helpers;
 using WalletWasabi.Userfacing;
@@ -277,6 +276,7 @@ namespace WalletWasabi.Packager
 					$"/p:ErrorReport=none",
 					$"/p:DocumentationFile=\"\"",
 					$"/p:Deterministic=true",
+					$"/p:ContinuousIntegrationBuild=true",
 					$"/p:RestoreLockedMode=true");
 
 				StartProcessAndWaitForExit(

--- a/WalletWasabi.Packager/WalletWasabi.Packager.csproj
+++ b/WalletWasabi.Packager/WalletWasabi.Packager.csproj
@@ -14,7 +14,6 @@
 		<DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
 		<InvariantGlobalization>true</InvariantGlobalization>
 		<RuntimeIdentifiers>win7-x64;linux-x64;osx-x64</RuntimeIdentifiers>
-		<PathMap>$(MSBuildProjectDirectory)\=WalletWasabi.Packager</PathMap>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/WalletWasabi.Tests/WalletWasabi.Tests.csproj
+++ b/WalletWasabi.Tests/WalletWasabi.Tests.csproj
@@ -15,7 +15,6 @@
 		<Nullable>enable</Nullable>
 		<InvariantGlobalization>true</InvariantGlobalization>
 		<RuntimeIdentifiers>win7-x64;linux-x64;osx-x64</RuntimeIdentifiers>
-		<PathMap>$(MSBuildProjectDirectory)\=WalletWasabi.Tests</PathMap>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/WalletWasabi/WalletWasabi.csproj
+++ b/WalletWasabi/WalletWasabi.csproj
@@ -13,7 +13,6 @@
 		<DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
 		<InvariantGlobalization>true</InvariantGlobalization>
 		<RuntimeIdentifiers>win7-x64;linux-x64;osx-x64</RuntimeIdentifiers>
-		<PathMap>$(MSBuildProjectDirectory)\=WalletWasabi</PathMap>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">


### PR DESCRIPTION
- Tests with coverage on codecov, and test result artifacts for Visual Studio `.trx` files
- `dotnet publish` used to build backend (buit on windows, mac & linux).
  - See [WalletWasabi.Documentation/BackendDeployment.md](https://github.com/Bitcoin-Eagles/EagleSabi/blob/73e67847fc094bd26248d56e991e712064bc56a7/WalletWasabi.Documentation/BackendDeployment.md)
  - build artifacts are wasteful because `Microservices` contains all platform binaries
- the Packager project is used to build gui  with `/p:ContinuousIntegrationBuild=true` added and `PathMap` removed.
  - See  [WalletWasabi.Documentation/DeterministicBuildGuide.md](https://github.com/Bitcoin-Eagles/EagleSabi/blob/73e67847fc094bd26248d56e991e712064bc56a7/WalletWasabi.Documentation/Guides/DeterministicBuildGuide.md)
  - all 3 targets are built built on windows and linux targeting, macos falls over
  - build artifacts are large, not sure if that's normal