### PR TITLE
Split building & testing to avoid clogging github

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,61 @@
+name: build
+
+on:
+  push:
+
+env:
+  DOTNET_VERSION: '6.0.101'
+
+jobs:
+  build-backend:
+    name: build-backend-${{matrix.os}}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup .NET Core
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: ${{ env.DOTNET_VERSION }}
+
+    - name: Restore
+      run: dotnet restore
+
+    - name: Publish
+      run: dotnet publish --configuration Release --self-contained false /p:ContinuousIntegrationBuild=true WalletWasabi.Backend
+
+    - uses: actions/upload-artifact@v2
+      with:
+        name: Backend (built on ${{matrix.os}})
+        path: "WalletWasabi.Backend/bin/Release/*/publish"
+
+  build-gui-with-packager:
+    name: build-gui-${{matrix.os}}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup .NET Core
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: ${{ env.DOTNET_VERSION }}
+
+    - name: Restore
+      run: dotnet restore
+
+    - name: Build Packager
+      run: dotnet build --no-restore WalletWasabi.Packager
+
+    - name: Packager
+      run: cd WalletWasabi.Packager; dotnet run -- --onlybinaries
+
+    - uses: actions/upload-artifact@v2
+      with:
+        name: Packager outputs (built on ${{matrix.os}})
+        path: "*/bin/dist"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: build and test
+name: test
 
 on:
   push:
@@ -53,56 +53,3 @@ jobs:
     - uses: codecov/codecov-action@v2
       with:
         fail_ci_if_error: true
-
-  build-backend:
-    name: build-backend-${{matrix.os}}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest, macOS-latest]
-
-    steps:
-    - uses: actions/checkout@v2
-    - name: Setup .NET Core
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNET_VERSION }}
-
-    - name: Restore
-      run: dotnet restore
-
-    - name: Publish
-      run: dotnet publish --configuration Release --self-contained false /p:ContinuousIntegrationBuild=true WalletWasabi.Backend
-
-    - uses: actions/upload-artifact@v2
-      with:
-        name: Backend (built on ${{matrix.os}})
-        path: "WalletWasabi.Backend/bin/Release/*/publish"
-
-  build-gui-with-packager:
-    name: build-gui-${{matrix.os}}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest]
-
-    steps:
-    - uses: actions/checkout@v2
-    - name: Setup .NET Core
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ env.DOTNET_VERSION }}
-
-    - name: Restore
-      run: dotnet restore
-
-    - name: Build Packager
-      run: dotnet build --no-restore WalletWasabi.Packager
-
-    - name: Packager
-      run: cd WalletWasabi.Packager; dotnet run -- --onlybinaries
-
-    - uses: actions/upload-artifact@v2
-      with:
-        name: Packager outputs (built on ${{matrix.os}})
-        path: "*/bin/dist"


### PR DESCRIPTION
The build artifacts are rather large, so avoid running build jobs for
pull requests, only pushes (i.e. merges to master). Tests are still run
on everything.

(P.S. sorry for merging my own pull request and then following up...)